### PR TITLE
Fix navbar layout and restore touch scrolling

### DIFF
--- a/frontend/ashaven-ui/src/app/components/navbar/navbar.component.css
+++ b/frontend/ashaven-ui/src/app/components/navbar/navbar.component.css
@@ -6,7 +6,7 @@
   position: relative;
   display: flex;
   justify-content: center;
-  padding: clamp(1rem, 2.4vw, 1.75rem) 0;
+  padding: clamp(0.35rem, 1.4vw, 0.85rem) 0;
   transition: transform 0.6s cubic-bezier(0.77, 0, 0.175, 1),
     opacity 0.6s ease, filter 0.6s ease;
 }
@@ -44,9 +44,9 @@
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: clamp(1rem, 3vw, 2.5rem);
-  padding: clamp(0.75rem, 1.6vw, 1.15rem)
-    clamp(1rem, 3vw, 2.25rem);
+  gap: clamp(0.75rem, 2vw, 1.4rem);
+  padding: clamp(0.35rem, 1vw, 0.7rem)
+    clamp(0.85rem, 3vw, 1.75rem);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.92);
   border: 1px solid rgba(32, 71, 38, 0.1);
@@ -70,19 +70,12 @@
 
 .neo-nav__links--primary {
   justify-self: flex-start;
+  grid-column: 1;
 }
 
 .neo-nav__links--secondary {
   justify-self: flex-end;
-}
-
-@media (min-width: 768px) {
-  .neo-nav__links {
-    display: flex;
-  }
-
-.neo-nav__links--secondary {
-  justify-self: flex-end;
+  grid-column: 3;
 }
 
 .neo-nav__link {
@@ -123,22 +116,29 @@
   display: inline-flex;
   align-items: center;
   gap: 0.85rem;
-  padding: 0.35rem 0.65rem;
+  padding: 0.25rem 0.6rem;
   border-radius: 1.5rem;
   transition: transform 0.35s ease;
+  grid-column: 1;
+  justify-self: flex-start;
 }
 
 .neo-nav__brand:hover {
   transform: translateY(-4px) scale(1.01);
 }
 
-
 .neo-nav__brand-copy {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   background: linear-gradient(135deg, rgba(32, 71, 38, 0.9), rgba(18, 45, 27, 0.95));
   border-radius: 1.2rem;
-  padding: 0px 10px 0px 10px;
+  padding: 0 10px;
+}
+
+.neo-nav__brand-copy img {
+  height: clamp(42px, 5vw, 48px);
+  width: auto;
 }
 
 .neo-nav__brand-copy span {
@@ -186,6 +186,8 @@
   box-shadow: 0 12px 28px rgba(19, 53, 31, 0.18);
   transition: transform 0.35s ease, border-color 0.35s ease;
   z-index: 2;
+  grid-column: 3;
+  justify-self: flex-end;
 }
 
 .neo-nav__menu-line {
@@ -212,11 +214,39 @@
   display: inline-flex;
 }
 
-/* Hide menu button on desktop */
-@media (min-width: 768px) {
+@media (max-width: 767px) {
+  .neo-nav__inner {
+    gap: clamp(0.5rem, 3vw, 1rem);
+    padding: clamp(0.35rem, 3vw, 0.6rem) clamp(0.75rem, 5vw, 1.25rem);
+  }
+
+  .neo-nav__brand {
+    grid-column: 1;
+    justify-self: flex-start;
+  }
+
   .neo-nav__menu {
-    display: none;
+    grid-column: 3;
+    justify-self: flex-end;
   }
 }
 
+/* Desktop layout */
+@media (min-width: 768px) {
+  .neo-nav__inner {
+    gap: clamp(1rem, 2.5vw, 2rem);
+  }
+
+  .neo-nav__links {
+    display: flex;
+  }
+
+  .neo-nav__brand {
+    grid-column: 2;
+    justify-self: center;
+  }
+
+  .neo-nav__menu {
+    display: none;
+  }
 }

--- a/frontend/ashaven-ui/src/app/components/side-panel/side-panel.component.css
+++ b/frontend/ashaven-ui/src/app/components/side-panel/side-panel.component.css
@@ -1,6 +1,12 @@
+.side-panel {
+  background: linear-gradient(165deg, rgba(255, 255, 255, 0.96), rgba(241, 251, 236, 0.92));
+  backdrop-filter: blur(16px);
+  border-left: 1px solid rgba(32, 71, 38, 0.08);
+}
+
 .side-panel.open {
   right: 0;
-  background-color: var(--accentLight);
+  background-color: rgba(241, 251, 236, 0.98);
   box-shadow: rgba(0, 0, 0, 0.6) 0px -7px 27px 3px;
 }
 

--- a/frontend/ashaven-ui/src/app/services/lenis.service.ts
+++ b/frontend/ashaven-ui/src/app/services/lenis.service.ts
@@ -11,6 +11,7 @@ export class LenisService {
   private router = inject(Router);
   private rafId?: number;
   private motionQuery?: MediaQueryList;
+  private viewportQuery?: MediaQueryList;
 
   constructor() {
     if (typeof window === 'undefined') {
@@ -34,6 +35,22 @@ export class LenisService {
       motionQuery.addListener(handleMotionPreference);
     }
 
+    this.viewportQuery = window.matchMedia('(max-width: 767px)');
+    const viewportQuery = this.viewportQuery;
+    const handleViewportChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        this.stopLenis();
+      } else {
+        this.init();
+      }
+    };
+
+    if (typeof viewportQuery.addEventListener === 'function') {
+      viewportQuery.addEventListener('change', handleViewportChange);
+    } else if (typeof viewportQuery.addListener === 'function') {
+      viewportQuery.addListener(handleViewportChange);
+    }
+
     this.init();
     this.handleRouteChange();
   }
@@ -54,9 +71,19 @@ export class LenisService {
       return;
     }
 
-    const isFinePointer = window.matchMedia('(pointer: fine)').matches;
+    const viewportQuery = this.viewportQuery ?? window.matchMedia('(max-width: 767px)');
+    if (viewportQuery.matches) {
+      this.stopLenis();
+      return;
+    }
+
+    const prefersTouchInput = window.matchMedia('(pointer: coarse)').matches;
 
     this.stopLenis();
+
+    if (prefersTouchInput) {
+      return;
+    }
 
     this.lenis = new Lenis({
       duration: 1.05,


### PR DESCRIPTION
## Summary
- tighten the navbar spacing, trim its padding, and enlarge the brand logo while keeping controls aligned across breakpoints
- keep the logo visible on mobile with explicit sizing while maintaining desktop styling
- disable Lenis smoothing on coarse pointer devices and small viewports so touch scrolling continues to work
- add a soft gradient background to the slide-in side panel for clearer separation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0ef5e85ac832396fbee3cccbfe4d7