### PR TITLE
feat: refresh gallery page with modern layout

### DIFF
--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.css
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.css
@@ -1,1 +1,186 @@
+:host {
+  display: block;
+}
 
+.gallery-hero {
+  position: relative;
+  min-height: clamp(420px, 60vh, 600px);
+  border-radius: clamp(1.5rem, 4vw, 3rem);
+  overflow: hidden;
+  background: #060814;
+  display: grid;
+  align-items: stretch;
+}
+
+.gallery-hero__background {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.gallery-hero__media {
+  position: absolute;
+  inset: -12% -6% 0;
+  will-change: transform;
+  transition: transform 0.35s ease;
+  z-index: 1;
+}
+
+.gallery-hero__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(105%) contrast(105%);
+  transform: scale(1.05);
+}
+
+.gallery-hero__gradient {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(13, 17, 38, 0.85), rgba(6, 8, 20, 0.92));
+  z-index: 2;
+}
+
+.gallery-hero__glow {
+  position: absolute;
+  width: 22rem;
+  height: 22rem;
+  filter: blur(70px);
+  opacity: 0.65;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.gallery-hero__glow--left {
+  top: 12%;
+  left: -5%;
+  background: radial-gradient(circle, rgba(100, 115, 255, 0.75), transparent 70%);
+}
+
+.gallery-hero__glow--right {
+  bottom: -6%;
+  right: -3%;
+  background: radial-gradient(circle, rgba(255, 122, 84, 0.65), transparent 70%);
+}
+
+.gallery-hero__content {
+  position: relative;
+  z-index: 3;
+  display: grid;
+  gap: 1.25rem;
+  padding: clamp(2.5rem, 8vw, 5rem) clamp(1.75rem, 8vw, 5rem);
+  color: #f8f9ff;
+  max-width: 680px;
+}
+
+.gallery-hero__badge {
+  width: fit-content;
+  padding: 0.35rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(18px);
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.gallery-hero__title {
+  font-size: clamp(2.75rem, 2rem + 2.5vw, 4rem);
+  font-weight: 600;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.gallery-hero__subtitle {
+  font-size: clamp(1.05rem, 0.9rem + 0.8vw, 1.35rem);
+  color: rgba(241, 244, 255, 0.78);
+  line-height: 1.7;
+}
+
+.gallery-hero__breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+  color: rgba(241, 244, 255, 0.7);
+}
+
+.gallery-hero__breadcrumb-link {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+}
+
+.gallery-hero__breadcrumb-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.15rem;
+  width: 100%;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.4);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.gallery-hero__breadcrumb-link:hover::after,
+.gallery-hero__breadcrumb-link:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.gallery-hero__breadcrumb-link:focus-visible {
+  outline: 2px solid rgba(160, 172, 255, 0.6);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.gallery-hero__breadcrumb-current {
+  color: rgba(241, 244, 255, 0.9);
+}
+
+.gallery-hero__meta {
+  display: grid;
+  gap: 0.85rem;
+  max-width: 420px;
+}
+
+@media (min-width: 768px) {
+  .gallery-hero__meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.gallery-hero__meta-card {
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: rgba(10, 13, 30, 0.6);
+  backdrop-filter: blur(22px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.gallery-hero__meta-eyebrow {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(201, 208, 255, 0.6);
+  margin-bottom: 0.45rem;
+}
+
+.gallery-hero__meta-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(248, 249, 255, 0.94);
+}
+
+@media (max-width: 768px) {
+  .gallery-hero {
+    border-radius: clamp(1.1rem, 4vw, 2rem);
+  }
+
+  .gallery-hero__background {
+    opacity: 0.92;
+  }
+}

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
@@ -1,23 +1,40 @@
-<div class="relative">
-
-  <!-- Hero Banner with fixed parallax -->
-  <div class="relative w-full h-[60vh] md:h-[80vh] overflow-hidden">
-    <!-- Background Image -->
-    <div 
-      class="absolute top-0 left-0 w-full h-[120%] bg-cover bg-center transform-gpu will-change-transform"
-      style="background-image: url('/images/banner/banner-3.png');"
-      [ngStyle]="{'transform': 'translateY(' + (scrollY * 0.3 - 60) + 'px)'}">
+<section class="gallery-hero" aria-labelledby="galleryHeroTitle">
+  <div class="gallery-hero__background">
+    <div
+      class="gallery-hero__media"
+      [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.2) + 'px)' }"
+    >
+      <img
+        src="/images/banner/banner-3.png"
+        alt="Gallery showcase"
+        loading="lazy"
+      />
     </div>
+    <div class="gallery-hero__gradient"></div>
+    <div class="gallery-hero__glow gallery-hero__glow--left"></div>
+    <div class="gallery-hero__glow gallery-hero__glow--right"></div>
+  </div>
 
-    <!-- Optional overlay -->
-    <div class="absolute inset-0 bg-black/40"></div>
-
-    <!-- Centered content -->
-    <div class="relative z-10 flex flex-col items-center justify-center h-full px-5 gap-2">
-      <div class="inline-flex items-baseline gap-2 backdrop-blur-md rounded-2xl px-6 py-4 shadow-lg max-w-[85%]">
-        <h1 class="text-4xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-[var(--light)]">Gallery</h1>
+  <div class="gallery-hero__content">
+    <div class="gallery-hero__badge">Immersive showcase</div>
+    <h1 class="gallery-hero__title" id="galleryHeroTitle">Gallery</h1>
+    <p class="gallery-hero__subtitle">
+      Discover the crafted stories, moods, and spaces that define AS Haven.
+    </p>
+    <nav class="gallery-hero__breadcrumb" aria-label="Breadcrumb">
+      <a routerLink="/" class="gallery-hero__breadcrumb-link">Home</a>
+      <span aria-hidden="true" class="gallery-hero__breadcrumb-separator">/</span>
+      <span class="gallery-hero__breadcrumb-current">Gallery</span>
+    </nav>
+    <div class="gallery-hero__meta">
+      <div class="gallery-hero__meta-card">
+        <span class="gallery-hero__meta-eyebrow">Curated visions</span>
+        <span class="gallery-hero__meta-value">Architectural artistry</span>
       </div>
-      <p class="text-lg sm:text-xl text-[var(--light)]">Home > Gallery</p>
+      <div class="gallery-hero__meta-card">
+        <span class="gallery-hero__meta-eyebrow">Experience</span>
+        <span class="gallery-hero__meta-value">Still &amp; motion stories</span>
+      </div>
     </div>
   </div>
-</div>
+</section>

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.css
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.css
@@ -132,6 +132,76 @@
   letter-spacing: 0.08em;
 }
 
+.gallery-section__panel {
+  background: rgba(255, 255, 255, 0.68);
+  border-radius: 1.75rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(46, 61, 112, 0.08);
+  box-shadow: 0 20px 40px rgba(20, 28, 65, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.gallery-section__panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.gallery-section__panel-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.gallery-section__panel-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(33, 41, 86, 0.75);
+}
+
+.gallery-section__panel-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #4158f5, #7a89ff);
+  box-shadow: 0 0 0 6px rgba(65, 88, 245, 0.15);
+}
+
+.gallery-section__refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.25rem;
+  background: linear-gradient(120deg, #1e2d78, #425ae6);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  box-shadow: 0 16px 30px rgba(33, 53, 160, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gallery-section__refresh:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(33, 53, 160, 0.32);
+}
+
+.gallery-section__refresh:focus-visible {
+  outline: 3px solid rgba(113, 132, 255, 0.6);
+  outline-offset: 3px;
+}
+
+.gallery-section__refresh-icon {
+  font-size: 1rem;
+}
+
 .gallery-section__filters {
   display: inline-flex;
   align-items: center;
@@ -189,6 +259,105 @@
 .gallery-filter.is-active .gallery-filter__count {
   background: rgba(255, 255, 255, 0.28);
   color: #fff;
+}
+
+.gallery-error {
+  display: flex;
+  justify-content: center;
+}
+
+.gallery-error__card {
+  width: min(480px, 90vw);
+  padding: 2rem;
+  border-radius: 1.5rem;
+  background: rgba(255, 237, 236, 0.95);
+  border: 1px solid rgba(204, 90, 84, 0.12);
+  box-shadow: 0 24px 48px rgba(160, 35, 30, 0.14);
+  text-align: center;
+}
+
+.gallery-error__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #7d1f1a;
+  margin-bottom: 0.75rem;
+}
+
+.gallery-error__copy {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(125, 31, 26, 0.8);
+  margin-bottom: 1.25rem;
+}
+
+.gallery-error__retry {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: linear-gradient(120deg, #ff7a54, #ff9f6f);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(255, 122, 84, 0.24);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gallery-error__retry:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px rgba(255, 122, 84, 0.28);
+}
+
+.gallery-error__retry:focus-visible {
+  outline: 3px solid rgba(255, 171, 140, 0.65);
+  outline-offset: 4px;
+}
+
+.gallery-skeleton {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.gallery-skeleton__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.gallery-skeleton__card {
+  border-radius: 1.75rem;
+  background: linear-gradient(120deg, rgba(235, 238, 255, 0.6), rgba(226, 230, 255, 0.85));
+  position: relative;
+  overflow: hidden;
+  min-height: 220px;
+}
+
+.gallery-skeleton__card--hero {
+  min-height: 420px;
+}
+
+.gallery-skeleton__card--tall {
+  min-height: 280px;
+}
+
+.gallery-skeleton__card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    110deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.7) 35%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  animation: galleryShimmer 1.8s ease-in-out infinite;
+}
+
+@keyframes galleryShimmer {
+  to {
+    transform: translateX(100%);
+  }
 }
 
 .gallery-section__grid {
@@ -467,6 +636,14 @@
 @media (max-width: 768px) {
   .gallery-section__filters {
     flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .gallery-section__panel-content {
+    align-items: stretch;
+  }
+
+  .gallery-section__panel-actions {
     justify-content: center;
   }
 

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.html
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.html
@@ -10,9 +10,9 @@
       <div class="gallery-section__heading">
         <h2 class="gallery-section__title">Project Gallery</h2>
         <p class="gallery-section__description">
-          From visionary renderings to lived-in scenes, explore the crafted
-          stories that define AS Haven. Each capture celebrates the light,
-          textures, and perspectives that make our residences feel like art.
+          From visionary renderings to lived-in scenes, explore the curated
+          narratives that define AS Haven. Every capture celebrates light,
+          craftsmanship, and the mood of each residence.
         </p>
       </div>
 
@@ -32,142 +32,183 @@
       </div>
     </div>
 
-    <div
-      class="gallery-section__filters fade-up"
-      role="tablist"
-      aria-label="Gallery filters"
-    >
-      <button
-        type="button"
-        class="gallery-filter"
-        [class.is-active]="activeFilter === 'all'"
-        (click)="setFilter('all')"
-        [attr.aria-pressed]="activeFilter === 'all'"
-        role="tab"
-        [attr.aria-selected]="activeFilter === 'all'"
-      >
-        All
-        <span class="gallery-filter__count">{{ totalItems }}</span>
-      </button>
-      <button
-        type="button"
-        class="gallery-filter"
-        [class.is-active]="activeFilter === 'image'"
-        (click)="setFilter('image')"
-        [attr.aria-pressed]="activeFilter === 'image'"
-        role="tab"
-        [attr.aria-selected]="activeFilter === 'image'"
-      >
-        Images
-        <span class="gallery-filter__count">{{ totalImages }}</span>
-      </button>
-      <button
-        type="button"
-        class="gallery-filter"
-        [class.is-active]="activeFilter === 'video'"
-        (click)="setFilter('video')"
-        [attr.aria-pressed]="activeFilter === 'video'"
-        role="tab"
-        [attr.aria-selected]="activeFilter === 'video'"
-      >
-        Videos
-        <span class="gallery-filter__count">{{ totalVideos }}</span>
-      </button>
-    </div>
-
-    <ng-container *ngIf="filteredGalleryItems.length; else emptyGallery">
-      <div class="gallery-section__grid fade-up">
-        <ng-container *ngIf="featuredItem as hero">
+    <div class="gallery-section__panel fade-up" role="region" aria-live="polite">
+      <div class="gallery-section__panel-content">
+        <div class="gallery-section__filters" role="tablist" aria-label="Gallery filters">
           <button
             type="button"
-            class="gallery-card gallery-card--featured"
-            (click)="openItem(hero)"
-            [attr.aria-label]="getAriaLabel(hero)"
+            class="gallery-filter"
+            [class.is-active]="activeFilter === 'all'"
+            (click)="setFilter('all')"
+            [attr.aria-pressed]="activeFilter === 'all'"
+            role="tab"
+            [attr.aria-selected]="activeFilter === 'all'"
           >
-            <span class="gallery-card__media">
-              <img
-                *ngIf="isImage(hero)"
-                [src]="mediaUrl(hero)"
-                [alt]="hero.title"
-                loading="lazy"
-                class="gallery-card__media-el"
-                (error)="onImageError($event)"
-              />
-              <video
-                *ngIf="isVideo(hero)"
-                [src]="mediaUrl(hero)"
-                muted
-                loop
-                playsinline
-                preload="metadata"
-                class="gallery-card__media-el"
-                (error)="onImageError($event)"
-              ></video>
-            </span>
-
-            <span class="gallery-card__overlay">
-              <span class="gallery-card__chip" [class.is-video]="isVideo(hero)">
-                {{ isVideo(hero) ? 'Video' : 'Image' }}
-              </span>
-              <span class="gallery-card__title">
-                {{ hero.title || 'Untitled showcase' }}
-              </span>
-              <span
-                *ngIf="hero.description"
-                class="gallery-card__description"
-                >{{ hero.description }}</span
-              >
-              <span class="gallery-card__cta">View showcase</span>
-            </span>
+            All
+            <span class="gallery-filter__count">{{ totalItems }}</span>
           </button>
-        </ng-container>
-
-        <div class="gallery-section__grid-inner">
           <button
             type="button"
-            class="gallery-card"
-            *ngFor="let item of supportingItems; trackBy: trackById"
-            (click)="openItem(item)"
-            [attr.aria-label]="getAriaLabel(item)"
+            class="gallery-filter"
+            [class.is-active]="activeFilter === 'image'"
+            (click)="setFilter('image')"
+            [attr.aria-pressed]="activeFilter === 'image'"
+            role="tab"
+            [attr.aria-selected]="activeFilter === 'image'"
           >
-            <span class="gallery-card__media">
-              <img
-                *ngIf="isImage(item)"
-                [src]="mediaUrl(item)"
-                [alt]="item.title"
-                loading="lazy"
-                class="gallery-card__media-el"
-                (error)="onImageError($event)"
-              />
-              <video
-                *ngIf="isVideo(item)"
-                [src]="mediaUrl(item)"
-                muted
-                loop
-                playsinline
-                preload="metadata"
-                class="gallery-card__media-el"
-                (error)="onImageError($event)"
-              ></video>
-            </span>
+            Images
+            <span class="gallery-filter__count">{{ totalImages }}</span>
+          </button>
+          <button
+            type="button"
+            class="gallery-filter"
+            [class.is-active]="activeFilter === 'video'"
+            (click)="setFilter('video')"
+            [attr.aria-pressed]="activeFilter === 'video'"
+            role="tab"
+            [attr.aria-selected]="activeFilter === 'video'"
+          >
+            Videos
+            <span class="gallery-filter__count">{{ totalVideos }}</span>
+          </button>
+        </div>
 
-            <span class="gallery-card__overlay">
-              <span class="gallery-card__chip" [class.is-video]="isVideo(item)">
-                {{ isVideo(item) ? 'Video' : 'Image' }}
-              </span>
-              <span class="gallery-card__title">
-                {{ item.title || 'Untitled showcase' }}
-              </span>
-              <span
-                *ngIf="item.description"
-                class="gallery-card__description"
-                >{{ item.description }}</span
-              >
-            </span>
+        <div class="gallery-section__panel-actions">
+          <span *ngIf="!isLoading && !loadError" class="gallery-section__panel-status">
+            <span class="gallery-section__panel-dot" aria-hidden="true"></span>
+            {{ filteredGalleryItems.length }} curated
+            {{ activeFilter === 'video' ? 'reels' : activeFilter === 'image' ? 'stills' : 'stories' }}
+          </span>
+          <button class="gallery-section__refresh" type="button" (click)="loadGalleryItems()">
+            <span class="gallery-section__refresh-icon" aria-hidden="true">⟲</span>
+            Refresh
           </button>
         </div>
       </div>
+    </div>
+
+    <div *ngIf="loadError" class="gallery-error fade-up" role="alert">
+      <div class="gallery-error__card">
+        <h3 class="gallery-error__title">We couldn't load the gallery.</h3>
+        <p class="gallery-error__copy">
+          Please check your connection and try again. The curated visuals will
+          be right back.
+        </p>
+        <button class="gallery-error__retry" type="button" (click)="loadGalleryItems()">
+          Try again
+        </button>
+      </div>
+    </div>
+
+    <ng-container *ngIf="isLoading; else galleryContent">
+      <div class="gallery-skeleton fade-up" aria-hidden="true">
+        <div class="gallery-skeleton__card gallery-skeleton__card--hero"></div>
+        <div class="gallery-skeleton__grid">
+          <div
+            class="gallery-skeleton__card"
+            *ngFor="let placeholder of skeletonPlaceholders; index as i"
+            [class.gallery-skeleton__card--tall]="i % 3 === 0"
+          ></div>
+        </div>
+      </div>
     </ng-container>
+
+    <ng-template #galleryContent>
+      <ng-container *ngIf="filteredGalleryItems.length; else emptyGallery">
+        <div class="gallery-section__grid fade-up">
+          <ng-container *ngIf="featuredItem as hero">
+            <button
+              type="button"
+              class="gallery-card gallery-card--featured"
+              (click)="openItem(hero)"
+              [attr.aria-label]="getAriaLabel(hero)"
+            >
+              <span class="gallery-card__media">
+                <img
+                  *ngIf="isImage(hero)"
+                  [src]="mediaUrl(hero)"
+                  [alt]="hero.title"
+                  loading="lazy"
+                  class="gallery-card__media-el"
+                  (error)="onImageError($event)"
+                />
+                <video
+                  *ngIf="isVideo(hero)"
+                  [src]="mediaUrl(hero)"
+                  muted
+                  loop
+                  playsinline
+                  preload="metadata"
+                  class="gallery-card__media-el"
+                  (error)="onImageError($event)"
+                ></video>
+              </span>
+
+              <span class="gallery-card__overlay">
+                <span class="gallery-card__chip" [class.is-video]="isVideo(hero)">
+                  {{ isVideo(hero) ? 'Video' : 'Image' }}
+                </span>
+                <span class="gallery-card__title">
+                  {{ hero.title || 'Untitled showcase' }}
+                </span>
+                <span *ngIf="hero.description" class="gallery-card__description">
+                  {{ hero.description }}
+                </span>
+                <span class="gallery-card__cta">
+                  {{ isVideo(hero) ? 'Watch reel' : 'View still' }}
+                </span>
+              </span>
+            </button>
+          </ng-container>
+
+          <div class="gallery-section__grid-inner">
+            <button
+              type="button"
+              class="gallery-card"
+              *ngFor="let item of supportingItems; trackBy: trackById"
+              (click)="openItem(item)"
+              [attr.aria-label]="getAriaLabel(item)"
+            >
+              <span class="gallery-card__media">
+                <img
+                  *ngIf="isImage(item)"
+                  [src]="mediaUrl(item)"
+                  [alt]="item.title"
+                  loading="lazy"
+                  class="gallery-card__media-el"
+                  (error)="onImageError($event)"
+                />
+                <video
+                  *ngIf="isVideo(item)"
+                  [src]="mediaUrl(item)"
+                  muted
+                  loop
+                  playsinline
+                  preload="metadata"
+                  class="gallery-card__media-el"
+                  (error)="onImageError($event)"
+                ></video>
+              </span>
+
+              <span class="gallery-card__overlay">
+                <span class="gallery-card__chip" [class.is-video]="isVideo(item)">
+                  {{ isVideo(item) ? 'Video' : 'Image' }}
+                </span>
+                <span class="gallery-card__title">
+                  {{ item.title || 'Untitled showcase' }}
+                </span>
+                <span *ngIf="item.description" class="gallery-card__description">
+                  {{ item.description }}
+                </span>
+                <span class="gallery-card__cta">
+                  {{ isVideo(item) ? 'Watch reel' : 'View still' }}
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </ng-container>
+    </ng-template>
   </div>
 </section>
 
@@ -192,11 +233,7 @@
   (touchend)="onTouchEnd($event)"
 >
   <div class="gallery-lightbox__content">
-    <button
-      class="gallery-lightbox__close"
-      (click)="closeLightbox()"
-      aria-label="Close lightbox"
-    >
+    <button class="gallery-lightbox__close" (click)="closeLightbox()" aria-label="Close lightbox">
       <span aria-hidden="true">×</span>
     </button>
 
@@ -220,19 +257,11 @@
       ></video>
     </ng-container>
 
-    <button
-      class="gallery-lightbox__nav gallery-lightbox__nav--prev"
-      (click)="prevItem($event)"
-      aria-label="Previous item"
-    >
+    <button class="gallery-lightbox__nav gallery-lightbox__nav--prev" (click)="prevItem($event)" aria-label="Previous item">
       ❮
     </button>
 
-    <button
-      class="gallery-lightbox__nav gallery-lightbox__nav--next"
-      (click)="nextItem($event)"
-      aria-label="Next item"
-    >
+    <button class="gallery-lightbox__nav gallery-lightbox__nav--next" (click)="nextItem($event)" aria-label="Next item">
       ❯
     </button>
   </div>

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.ts
@@ -25,6 +25,9 @@ export class GalleryPageComponent implements OnInit, AfterViewInit {
   currentIndex = 0;
   baseUrl = environment.baseUrl;
   activeFilter: 'all' | 'image' | 'video' = 'all';
+  isLoading = false;
+  loadError = '';
+  skeletonPlaceholders = Array.from({ length: 6 });
 
   private touchStartX = 0;
   private touchEndX = 0;
@@ -46,15 +49,25 @@ export class GalleryPageComponent implements OnInit, AfterViewInit {
   }
 
   async loadGalleryItems(): Promise<void> {
+    this.isLoading = true;
+    this.loadError = '';
+    this.cdr.detectChanges();
+
     try {
       const items = await this.galleryService.getAll();
       this.galleryItems = items
         .filter((item) => item.isActive)
         .sort((a, b) => a.order - b.order);
-      this.cdr.detectChanges();
-      this.deferAnimationRefresh();
+
+      if (this.galleryItems.length) {
+        this.deferAnimationRefresh();
+      }
     } catch (error) {
       console.error('Failed to load gallery items:', error);
+      this.loadError = 'Unable to load gallery items at the moment.';
+    } finally {
+      this.isLoading = false;
+      this.cdr.detectChanges();
     }
   }
 
@@ -118,6 +131,7 @@ export class GalleryPageComponent implements OnInit, AfterViewInit {
     ) {
       this.closeLightbox();
     } else {
+      this.deferAnimationRefresh();
       this.cdr.detectChanges();
     }
   }


### PR DESCRIPTION
## Summary
- restyled the gallery hero with layered gradients, breadcrumb, and curated meta callouts for a modern look
- reimagined the gallery view with a floating filter panel, refreshed card overlays, and skeleton/error handling states
- added loading management, retry support, and animation refresh hooks to the gallery page component logic

## Testing
- npm run build -- --configuration=development

------
https://chatgpt.com/codex/tasks/task_e_68e222038f2c832391a4e4a0396aaad5