### PR TITLE
Align project and contact pages with brand palette

### DIFF
--- a/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.css
+++ b/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.css
@@ -4,9 +4,10 @@
 
 .hero-shell {
   min-height: 70vh;
-  background: radial-gradient(circle at 20% 20%, rgba(64, 224, 208, 0.12), transparent 50%),
-              radial-gradient(circle at 80% 10%, rgba(46, 204, 113, 0.16), transparent 55%),
-              linear-gradient(135deg, #0b1221 0%, #0e1a2f 45%, #102035 100%);
+  background:
+    radial-gradient(circle at 18% 22%, rgba(255, 119, 27, 0.18), transparent 55%),
+    radial-gradient(circle at 82% 12%, rgba(47, 118, 68, 0.22), transparent 60%),
+    linear-gradient(135deg, var(--luxe-forest-900, #132b18) 0%, #10331f 45%, #0d2618 100%);
 }
 
 .hero-media {
@@ -18,7 +19,7 @@
   inset: -10% -10% -20%;
   background-size: cover;
   background-position: center;
-  filter: saturate(1.1) brightness(0.9);
+  filter: saturate(1.05) brightness(0.75);
   transform-origin: center;
   transition: transform 0.2s ease-out;
 }
@@ -26,15 +27,15 @@
 .hero-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(8, 17, 32, 0.65) 0%, rgba(8, 17, 32, 0.95) 100%);
+  background: linear-gradient(180deg, rgba(13, 38, 24, 0.75) 0%, rgba(13, 38, 24, 0.95) 100%);
 }
 
 .hero-grid {
   position: absolute;
   inset: -20%;
   opacity: 0.25;
-  background-image: linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
-                    linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-image: linear-gradient(rgba(241, 251, 236, 0.12) 1px, transparent 1px),
+                    linear-gradient(90deg, rgba(241, 251, 236, 0.12) 1px, transparent 1px);
   background-size: 140px 140px;
   mask-image: radial-gradient(circle at center, black 0%, transparent 70%);
 }
@@ -51,7 +52,7 @@
 .hero-orb--one {
   width: 420px;
   height: 420px;
-  background: radial-gradient(circle, rgba(16, 185, 129, 0.35) 0%, rgba(16, 185, 129, 0) 70%);
+  background: radial-gradient(circle, rgba(255, 119, 27, 0.35) 0%, rgba(255, 119, 27, 0) 70%);
   top: -120px;
   right: -120px;
 }
@@ -59,7 +60,7 @@
 .hero-orb--two {
   width: 320px;
   height: 320px;
-  background: radial-gradient(circle, rgba(59, 130, 246, 0.35) 0%, rgba(59, 130, 246, 0) 70%);
+  background: radial-gradient(circle, rgba(47, 118, 68, 0.35) 0%, rgba(47, 118, 68, 0) 70%);
   bottom: -120px;
   left: -40px;
   animation-delay: -6s;
@@ -78,34 +79,34 @@
 }
 
 .hero-btn--primary {
-  color: #04121f;
-  background: linear-gradient(135deg, #34d399 0%, #22d3ee 100%);
-  box-shadow: 0 18px 35px rgba(45, 212, 191, 0.25);
+  color: var(--luxe-cream, #ffffff);
+  background: linear-gradient(135deg, var(--luxe-amber, #ff771b) 0%, #d65f13 100%);
+  box-shadow: 0 18px 35px rgba(255, 119, 27, 0.28);
 }
 
 .hero-btn--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 40px rgba(45, 212, 191, 0.35);
+  box-shadow: 0 20px 40px rgba(255, 119, 27, 0.38);
 }
 
 .hero-btn--ghost {
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  color: rgba(255, 255, 255, 0.85);
-  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(241, 251, 236, 0.28);
+  color: rgba(241, 251, 236, 0.88);
+  background: rgba(241, 251, 236, 0.08);
 }
 
 .hero-btn--ghost:hover {
   transform: translateY(-2px);
-  background: rgba(255, 255, 255, 0.16);
-  color: white;
+  background: rgba(241, 251, 236, 0.16);
+  color: var(--luxe-cream, #ffffff);
 }
 
 .info-panel {
-  background: linear-gradient(150deg, rgba(15, 118, 110, 0.25), rgba(37, 99, 235, 0.15));
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(150deg, rgba(32, 71, 38, 0.45), rgba(13, 38, 24, 0.6));
+  border: 1px solid rgba(241, 251, 236, 0.22);
   border-radius: 28px;
   padding: 1.9rem;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+  box-shadow: 0 24px 48px rgba(10, 30, 19, 0.48);
   backdrop-filter: blur(12px);
 }
 
@@ -119,8 +120,8 @@
   letter-spacing: 0.24em;
   padding: 0.55rem 1.2rem;
   border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.12);
-  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 119, 27, 0.16);
+  color: rgba(241, 251, 236, 0.92);
 }
 
 .info-chip {
@@ -129,30 +130,30 @@
   gap: 0.25rem;
   border-radius: 18px;
   padding: 1rem 1.1rem;
-  background: rgba(4, 18, 31, 0.45);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  background: rgba(13, 38, 24, 0.6);
+  border: 1px solid rgba(241, 251, 236, 0.12);
+  box-shadow: inset 0 1px 0 rgba(241, 251, 236, 0.16);
 }
 
 .info-chip .label {
   font-size: 0.75rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.55);
+  color: rgba(241, 251, 236, 0.6);
 }
 
 .info-chip .value {
   font-size: 0.95rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.92);
+  color: rgba(241, 251, 236, 0.95);
 }
 
 .promise-panel {
   border-radius: 24px;
   padding: 1.75rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(4, 18, 31, 0.72);
-  box-shadow: 0 12px 32px rgba(8, 23, 45, 0.45);
+  border: 1px solid rgba(241, 251, 236, 0.18);
+  background: rgba(13, 38, 24, 0.72);
+  box-shadow: 0 12px 32px rgba(8, 28, 18, 0.5);
   backdrop-filter: blur(10px);
 }
 
@@ -164,8 +165,8 @@
   height: 3rem;
   border-radius: 9999px;
   font-size: 1.4rem;
-  background: linear-gradient(135deg, rgba(52, 211, 153, 0.9), rgba(56, 189, 248, 0.9));
-  box-shadow: 0 10px 30px rgba(56, 189, 248, 0.25);
+  background: linear-gradient(135deg, rgba(255, 119, 27, 0.9), rgba(47, 118, 68, 0.9));
+  box-shadow: 0 10px 30px rgba(255, 119, 27, 0.28);
 }
 
 .pill {
@@ -173,8 +174,8 @@
   align-items: center;
   padding: 0.4rem 1.1rem;
   border-radius: 9999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(241, 251, 236, 0.14);
+  background: rgba(241, 251, 236, 0.08);
 }
 
 @keyframes float {

--- a/frontend/ashaven-ui/src/app/pages/contact/contact-info-map/contact-info-map.component.css
+++ b/frontend/ashaven-ui/src/app/pages/contact/contact-info-map/contact-info-map.component.css
@@ -3,16 +3,16 @@
 }
 
 .connect-section {
-  background: linear-gradient(135deg, #0b1221 0%, #0f1e33 45%, #132742 100%);
+  background: linear-gradient(135deg, var(--luxe-forest-900, #132b18) 0%, #0f2c1c 45%, #0c2216 100%);
   position: relative;
-  color: white;
+  color: rgba(241, 251, 236, 0.95);
 }
 
 .connect-gradient {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.25), transparent 60%),
-              radial-gradient(circle at bottom left, rgba(16, 185, 129, 0.24), transparent 55%);
+  background: radial-gradient(circle at top right, rgba(255, 119, 27, 0.28), transparent 60%),
+              radial-gradient(circle at bottom left, rgba(47, 118, 68, 0.28), transparent 55%);
   pointer-events: none;
 }
 
@@ -29,7 +29,7 @@
   height: 420px;
   top: -140px;
   left: -80px;
-  background: rgba(16, 185, 129, 0.45);
+  background: rgba(47, 118, 68, 0.45);
 }
 
 .connect-aurora--sky {
@@ -37,15 +37,15 @@
   height: 360px;
   bottom: -140px;
   right: -60px;
-  background: rgba(56, 189, 248, 0.4);
+  background: rgba(255, 119, 27, 0.35);
 }
 
 .connect-grid {
   position: absolute;
   inset: 0;
   opacity: 0.18;
-  background-image: linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
-                    linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-image: linear-gradient(rgba(241, 251, 236, 0.12) 1px, transparent 1px),
+                    linear-gradient(90deg, rgba(241, 251, 236, 0.12) 1px, transparent 1px);
   background-size: 160px 160px;
   mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.8) 40%, transparent 90%);
   pointer-events: none;
@@ -57,8 +57,8 @@
   gap: 0.45rem;
   padding: 0.65rem 1.5rem;
   border-radius: 9999px;
-  border: 1px solid rgba(255, 255, 255, 0.24);
-  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(241, 251, 236, 0.25);
+  background: rgba(241, 251, 236, 0.12);
   font-size: 0.8rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
@@ -74,12 +74,12 @@
 .stat-value {
   font-size: 2rem;
   font-weight: 700;
-  color: white;
+  color: var(--luxe-cream, #ffffff);
 }
 
 .stat-label {
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(241, 251, 236, 0.75);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -88,9 +88,9 @@
   position: relative;
   border-radius: 28px;
   padding: 2.2rem;
-  background: rgba(8, 23, 45, 0.78);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow: 0 30px 60px rgba(4, 12, 22, 0.45);
+  background: rgba(15, 46, 29, 0.78);
+  border: 1px solid rgba(241, 251, 236, 0.16);
+  box-shadow: 0 30px 60px rgba(6, 18, 11, 0.5);
   backdrop-filter: blur(14px);
 }
 
@@ -106,12 +106,12 @@
 .form-header h3 {
   font-size: 1.5rem;
   font-weight: 600;
-  color: white;
+  color: var(--luxe-cream, #ffffff);
 }
 
 .form-header p {
   margin-top: 0.4rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(241, 251, 236, 0.75);
 }
 
 .field-block {
@@ -125,28 +125,28 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(241, 251, 236, 0.65);
 }
 
 .field-input {
   width: 100%;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(12, 30, 50, 0.7);
-  color: white;
+  border: 1px solid rgba(241, 251, 236, 0.18);
+  background: rgba(10, 32, 20, 0.7);
+  color: var(--luxe-cream, #ffffff);
   padding: 0.9rem 1.1rem;
   font-size: 0.95rem;
   transition: border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
 .field-input::placeholder {
-  color: rgba(255, 255, 255, 0.35);
+  color: rgba(241, 251, 236, 0.4);
 }
 
 .field-input:focus {
   outline: none;
-  border-color: rgba(45, 212, 191, 0.7);
-  box-shadow: 0 0 0 4px rgba(45, 212, 191, 0.18);
+  border-color: rgba(255, 119, 27, 0.65);
+  box-shadow: 0 0 0 4px rgba(255, 119, 27, 0.18);
 }
 
 .field-textarea {
@@ -156,7 +156,7 @@
 
 .field-error {
   font-size: 0.8rem;
-  color: #fca5a5;
+  color: #fcbdb0;
 }
 
 .form-footer {
@@ -175,16 +175,16 @@
   border: none;
   font-weight: 600;
   font-size: 0.95rem;
-  color: #04121f;
-  background: linear-gradient(135deg, #34d399 0%, #22d3ee 100%);
-  box-shadow: 0 18px 35px rgba(45, 212, 191, 0.2);
+  color: var(--luxe-cream, #ffffff);
+  background: linear-gradient(135deg, var(--luxe-amber, #ff771b) 0%, #d65f13 100%);
+  box-shadow: 0 18px 35px rgba(255, 119, 27, 0.28);
   cursor: pointer;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .submit-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 22px 40px rgba(45, 212, 191, 0.28);
+  box-shadow: 0 22px 40px rgba(255, 119, 27, 0.35);
 }
 
 .submit-btn:disabled {
@@ -194,7 +194,7 @@
 
 .privacy-note {
   font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(241, 251, 236, 0.68);
 }
 
 .submit-feedback {
@@ -206,22 +206,22 @@
 }
 
 .submit-feedback.is-success {
-  background: rgba(45, 212, 191, 0.18);
-  color: #5ef5d8;
+  background: rgba(255, 119, 27, 0.16);
+  color: #ffe0c9;
 }
 
 .submit-feedback.is-error {
-  background: rgba(248, 113, 113, 0.15);
-  color: #fecaca;
+  background: rgba(220, 38, 38, 0.16);
+  color: #ffd6d6;
 }
 
 .map-card {
   position: relative;
   border-radius: 28px;
   padding: 2rem;
-  background: rgba(11, 27, 48, 0.78);
-  border: 1px solid rgba(148, 187, 233, 0.25);
-  box-shadow: 0 30px 60px rgba(4, 12, 22, 0.45);
+  background: rgba(12, 35, 22, 0.82);
+  border: 1px solid rgba(241, 251, 236, 0.18);
+  box-shadow: 0 30px 60px rgba(6, 18, 11, 0.5);
   backdrop-filter: blur(12px);
   display: flex;
   flex-direction: column;
@@ -230,7 +230,7 @@
 
 .map-card__header p {
   margin-top: 0.5rem;
-  color: rgba(221, 237, 255, 0.72);
+  color: rgba(241, 251, 236, 0.75);
 }
 
 .map-badge {
@@ -242,22 +242,22 @@
   letter-spacing: 0.28em;
   padding: 0.6rem 1.5rem;
   border-radius: 999px;
-  background: rgba(59, 130, 246, 0.2);
-  border: 1px solid rgba(147, 197, 253, 0.35);
+  background: rgba(255, 119, 27, 0.2);
+  border: 1px solid rgba(255, 153, 82, 0.35);
 }
 
 .map-frame {
   position: relative;
   overflow: hidden;
   border-radius: 22px;
-  border: 1px solid rgba(59, 130, 246, 0.25);
+  border: 1px solid rgba(255, 153, 82, 0.25);
   min-height: 320px;
 }
 
 .map-loading {
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(15, 118, 110, 0.25), rgba(59, 130, 246, 0.25));
+  background: linear-gradient(135deg, rgba(47, 118, 68, 0.25), rgba(255, 119, 27, 0.25));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -294,17 +294,17 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.25em;
-  color: rgba(148, 197, 253, 0.75);
+  color: rgba(241, 251, 236, 0.7);
 }
 
 .meta-desc {
-  color: rgba(224, 242, 254, 0.9);
+  color: rgba(241, 251, 236, 0.88);
 }
 
 .popup-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(4, 15, 27, 0.68);
+  background: rgba(7, 24, 15, 0.7);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -317,11 +317,11 @@
   width: min(400px, 100%);
   border-radius: 24px;
   padding: 2.4rem 2rem;
-  background: linear-gradient(160deg, rgba(8, 23, 45, 0.95), rgba(15, 32, 55, 0.92));
-  border: 1px solid rgba(59, 130, 246, 0.3);
-  box-shadow: 0 30px 80px rgba(2, 8, 23, 0.6);
+  background: linear-gradient(160deg, rgba(11, 40, 24, 0.95), rgba(14, 48, 28, 0.92));
+  border: 1px solid rgba(255, 153, 82, 0.3);
+  box-shadow: 0 30px 80px rgba(6, 18, 11, 0.6);
   text-align: center;
-  color: white;
+  color: rgba(241, 251, 236, 0.95);
 }
 
 .popup-icon {
@@ -336,7 +336,7 @@
 
 .popup-card p {
   margin-top: 0.75rem;
-  color: rgba(203, 213, 225, 0.9);
+  color: rgba(241, 251, 236, 0.75);
 }
 
 .popup-close {
@@ -345,7 +345,7 @@
   right: 1rem;
   background: transparent;
   border: none;
-  color: rgba(203, 213, 225, 0.85);
+  color: rgba(241, 251, 236, 0.75);
   font-size: 1.2rem;
   cursor: pointer;
 }

--- a/frontend/ashaven-ui/src/app/pages/contact/faq/faq.component.css
+++ b/frontend/ashaven-ui/src/app/pages/contact/faq/faq.component.css
@@ -3,14 +3,14 @@
 }
 
 .faq-section {
-  background: linear-gradient(180deg, #f1f5f9 0%, #ffffff 100%);
+  background: linear-gradient(180deg, var(--luxe-mist, #f1fbec) 0%, var(--luxe-cream, #ffffff) 100%);
   position: relative;
 }
 
 .faq-gradient {
   position: absolute;
   inset: 0;
-  background: linear-gradient(160deg, rgba(45, 212, 191, 0.12) 0%, rgba(59, 130, 246, 0.1) 40%, rgba(255, 255, 255, 0) 70%);
+  background: linear-gradient(160deg, rgba(255, 119, 27, 0.12) 0%, rgba(47, 118, 68, 0.12) 40%, rgba(255, 255, 255, 0) 70%);
 }
 
 .faq-aurora {
@@ -26,7 +26,7 @@
   height: 320px;
   top: -100px;
   left: -60px;
-  background: rgba(45, 212, 191, 0.38);
+  background: rgba(47, 118, 68, 0.3);
 }
 
 .faq-aurora--violet {
@@ -34,15 +34,15 @@
   height: 300px;
   bottom: -120px;
   right: -40px;
-  background: rgba(129, 140, 248, 0.32);
+  background: rgba(255, 119, 27, 0.28);
 }
 
 .faq-grid {
   position: absolute;
   inset: 0;
   opacity: 0.14;
-  background-image: linear-gradient(rgba(15, 23, 42, 0.07) 1px, transparent 1px),
-                    linear-gradient(90deg, rgba(15, 23, 42, 0.07) 1px, transparent 1px);
+  background-image: linear-gradient(rgba(32, 71, 38, 0.08) 1px, transparent 1px),
+                    linear-gradient(90deg, rgba(32, 71, 38, 0.08) 1px, transparent 1px);
   background-size: 120px 120px;
 }
 
@@ -56,24 +56,24 @@
   letter-spacing: 0.3em;
   font-size: 0.72rem;
   font-weight: 600;
-  color: #0f172a;
-  background: rgba(15, 118, 110, 0.14);
-  border: 1px solid rgba(14, 116, 144, 0.18);
+  color: var(--luxe-forest-900, #132b18);
+  background: rgba(255, 119, 27, 0.14);
+  border: 1px solid rgba(255, 119, 27, 0.28);
 }
 
 .faq-card {
   position: relative;
   border-radius: 26px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(32, 71, 38, 0.16);
+  background: rgba(255, 255, 255, 0.88);
   backdrop-filter: blur(18px);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 24px 48px rgba(32, 71, 38, 0.12);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .faq-card.is-open {
-  border-color: rgba(14, 165, 233, 0.45);
-  box-shadow: 0 28px 60px rgba(14, 165, 233, 0.18);
+  border-color: rgba(255, 119, 27, 0.4);
+  box-shadow: 0 28px 60px rgba(32, 71, 38, 0.16);
 }
 
 .faq-toggle {
@@ -100,13 +100,13 @@
   text-transform: uppercase;
   letter-spacing: 0.3em;
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.45);
+  color: rgba(32, 71, 38, 0.5);
 }
 
 .toggle-question {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--luxe-forest-900, #132b18);
 }
 
 .toggle-icon {
@@ -116,8 +116,8 @@
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 16px;
-  background: rgba(15, 118, 110, 0.14);
-  color: #0f172a;
+  background: rgba(255, 119, 27, 0.14);
+  color: var(--luxe-forest-900, #132b18);
   transition: transform 0.3s ease, background 0.3s ease;
 }
 
@@ -127,12 +127,12 @@
 
 .toggle-icon.is-open {
   transform: rotate(45deg);
-  background: rgba(14, 165, 233, 0.16);
+  background: rgba(255, 119, 27, 0.22);
 }
 
 .faq-answer {
   padding: 0 2rem 1.8rem;
-  color: #475569;
+  color: rgba(32, 71, 38, 0.7);
   line-height: 1.6;
 }
 

--- a/frontend/ashaven-ui/src/app/pages/contact/faq/faq.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/faq/faq.component.html
@@ -7,10 +7,10 @@
   <div class="relative max-w-5xl mx-auto px-6 py-20 md:py-24">
     <div class="text-center fade-up space-y-4">
       <span class="faq-pill">Frequently asked</span>
-      <h2 class="text-3xl md:text-4xl font-semibold text-slate-900">
+      <h2 class="text-3xl md:text-4xl font-semibold text-[var(--luxe-forest-900)]">
         Answers to the questions our residents ask the most.
       </h2>
-      <p class="text-slate-600 max-w-3xl mx-auto">
+      <p class="text-[rgba(32,71,38,0.7)] max-w-3xl mx-auto">
         We have compiled the insights that help you move forward faster. If you cannot find what you need, our concierge team is just a message away.
       </p>
     </div>

--- a/frontend/ashaven-ui/src/app/pages/contact/get-in-touch/get-in-touch.component.css
+++ b/frontend/ashaven-ui/src/app/pages/contact/get-in-touch/get-in-touch.component.css
@@ -3,15 +3,15 @@
 }
 
 .touch-section {
-  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
-              radial-gradient(circle at bottom right, rgba(16, 185, 129, 0.18), transparent 50%),
-              #f7fafc;
+  background: radial-gradient(circle at top left, rgba(255, 119, 27, 0.18), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(47, 118, 68, 0.18), transparent 50%),
+              var(--luxe-mist, #f1fbec);
 }
 
 .touch-gradient {
   position: absolute;
   inset: 0;
-  background: linear-gradient(160deg, rgba(59, 130, 246, 0.12) 0%, rgba(45, 212, 191, 0.08) 35%, rgba(255, 255, 255, 0) 70%);
+  background: linear-gradient(160deg, rgba(255, 119, 27, 0.12) 0%, rgba(47, 118, 68, 0.1) 35%, rgba(255, 255, 255, 0) 70%);
   pointer-events: none;
 }
 
@@ -28,7 +28,7 @@
   height: 380px;
   top: -120px;
   left: -80px;
-  background: rgba(45, 212, 191, 0.4);
+  background: rgba(255, 119, 27, 0.4);
 }
 
 .touch-aurora--two {
@@ -36,7 +36,7 @@
   height: 320px;
   bottom: -140px;
   right: -60px;
-  background: rgba(59, 130, 246, 0.35);
+  background: rgba(47, 118, 68, 0.35);
 }
 
 .touch-noise {
@@ -57,9 +57,9 @@
   font-weight: 600;
   letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: #0f172a;
-  background: rgba(15, 118, 110, 0.12);
-  border: 1px solid rgba(14, 116, 144, 0.16);
+  color: var(--luxe-forest-900, #132b18);
+  background: rgba(255, 119, 27, 0.12);
+  border: 1px solid rgba(255, 119, 27, 0.28);
 }
 
 .touch-card {
@@ -69,9 +69,9 @@
   gap: 1.3rem;
   padding: 2.4rem 2.2rem;
   border-radius: 28px;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(226, 239, 255, 0.9));
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(241, 251, 236, 0.92));
+  box-shadow: 0 24px 48px rgba(32, 71, 38, 0.12);
+  border: 1px solid rgba(32, 71, 38, 0.16);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
@@ -86,7 +86,7 @@
 
 .touch-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 30px 60px rgba(19, 53, 31, 0.18);
 }
 
 .icon-wrap {
@@ -98,29 +98,29 @@
   justify-content: center;
   font-size: 1.75rem;
   color: white;
-  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 15px 30px rgba(32, 71, 38, 0.2);
 }
 
 .icon-wrap--sunrise {
-  background: linear-gradient(135deg, #f97316, #fb7185);
+  background: linear-gradient(135deg, var(--luxe-amber, #ff771b), #ff9351);
 }
 
 .icon-wrap--emerald {
-  background: linear-gradient(135deg, #10b981, #22d3ee);
+  background: linear-gradient(135deg, #2f7644, var(--luxe-amber, #ff771b));
 }
 
 .icon-wrap--ruby {
-  background: linear-gradient(135deg, #ef4444, #f97316);
+  background: linear-gradient(135deg, #2f7644, #1b3b21);
 }
 
 .card-title {
   font-size: 1.4rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--luxe-forest-900, #132b18);
 }
 
 .card-copy {
-  color: #475569;
+  color: rgba(32, 71, 38, 0.7);
   line-height: 1.6;
 }
 
@@ -143,17 +143,17 @@
   text-transform: uppercase;
   letter-spacing: 0.28em;
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.55);
+  color: rgba(32, 71, 38, 0.6);
 }
 
 .meta-value {
   font-weight: 600;
-  color: #0f172a;
+  color: var(--luxe-forest-900, #132b18);
   text-decoration: none;
 }
 
 .meta-value:hover {
-  color: #0284c7;
+  color: var(--luxe-amber, #ff771b);
 }
 
 .card-cta {
@@ -162,10 +162,10 @@
   align-items: center;
   gap: 0.4rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--luxe-forest-900, #132b18);
   padding: 0.65rem 1.2rem;
   border-radius: 999px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(32, 71, 38, 0.2);
   transition: all 0.25s ease;
 }
 
@@ -175,8 +175,8 @@
 }
 
 .card-cta:hover {
-  color: #0ea5e9;
-  border-color: rgba(14, 165, 233, 0.4);
+  color: var(--luxe-amber, #ff771b);
+  border-color: rgba(255, 119, 27, 0.35);
   transform: translateX(4px);
 }
 
@@ -188,8 +188,8 @@
   margin-top: 4rem;
   border-radius: 32px;
   padding: 2.2rem;
-  background: linear-gradient(120deg, rgba(15, 118, 110, 0.14), rgba(59, 130, 246, 0.18));
-  border: 1px solid rgba(14, 165, 233, 0.25);
+  background: linear-gradient(120deg, rgba(32, 71, 38, 0.18), rgba(255, 119, 27, 0.18));
+  border: 1px solid rgba(32, 71, 38, 0.25);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
@@ -205,13 +205,13 @@
   letter-spacing: 0.32em;
   font-weight: 600;
   font-size: 0.75rem;
-  color: rgba(15, 23, 42, 0.6);
+  color: rgba(32, 71, 38, 0.6);
 }
 
 .banner-content h3 {
   font-size: 1.5rem;
   font-weight: 600;
-  color: #0f172a;
+  color: var(--luxe-forest-900, #132b18);
 }
 
 .banner-cta {
@@ -220,15 +220,15 @@
   gap: 0.5rem;
   padding: 0.75rem 1.6rem;
   border-radius: 999px;
-  background: #0f172a;
-  color: white;
+  background: linear-gradient(135deg, var(--luxe-amber, #ff771b), #d65f13);
+  color: var(--luxe-cream, #ffffff);
   font-weight: 600;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .banner-cta:hover {
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.25);
+  box-shadow: 0 16px 32px rgba(255, 119, 27, 0.3);
 }
 
 @media (min-width: 768px) {

--- a/frontend/ashaven-ui/src/app/pages/contact/get-in-touch/get-in-touch.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/get-in-touch/get-in-touch.component.html
@@ -7,10 +7,10 @@
   <div class="relative max-w-6xl mx-auto px-6 py-20 md:py-24">
     <div class="text-center fade-up space-y-4 max-w-3xl mx-auto">
       <span class="section-pill">Ways to reach us</span>
-      <h2 class="text-3xl sm:text-4xl lg:text-5xl font-semibold text-slate-900">
+      <h2 class="text-3xl sm:text-4xl lg:text-5xl font-semibold text-[var(--luxe-forest-900)]">
         A concierge team dedicated to making every conversation memorable.
       </h2>
-      <p class="text-base md:text-lg text-slate-600">
+      <p class="text-base md:text-lg text-[rgba(32,71,38,0.7)]">
         Whether you prefer a private tour, a quick voice note, or a detailed proposal, our specialists respond with the same care we give our residences.
       </p>
     </div>
@@ -84,7 +84,7 @@
       <div class="banner-content">
         <div>
           <p class="banner-eyebrow">Priority support</p>
-          <h3>Dedicated lifestyle curators for landowners &amp; investors.</h3>
+          <h3 class="text-[var(--luxe-forest-900)]">Dedicated lifestyle curators for landowners &amp; investors.</h3>
         </div>
         <a href="mailto:landowners@ashaven.com" class="banner-cta">Email our concierge</a>
       </div>

--- a/frontend/ashaven-ui/src/app/pages/project/project.component.css
+++ b/frontend/ashaven-ui/src/app/pages/project/project.component.css
@@ -3,8 +3,8 @@
 }
 
 .projects-page {
-  background: linear-gradient(180deg, #ffffff 0%, #eef1ff 100%);
-  color: #1e1e1e;
+  background: linear-gradient(180deg, var(--luxe-cream, #ffffff) 0%, var(--luxe-mist, #f1fbec) 60%, #e7f4e3 100%);
+  color: var(--luxe-ink, #1e1e1e);
 }
 
 .hero-section {
@@ -18,11 +18,11 @@
 }
 
 .hero-bg {
-  filter: saturate(1.05) brightness(0.9);
+  filter: saturate(1.05) brightness(0.85);
 }
 
 .hero-overlay {
-  background: linear-gradient(135deg, rgba(26, 27, 31, 0.75), rgba(26, 27, 31, 0.35));
+  background: linear-gradient(135deg, rgba(19, 53, 31, 0.85), rgba(32, 71, 38, 0.55));
 }
 
 .hero-content {
@@ -38,8 +38,8 @@
   gap: 0.5rem;
   padding: 0.45rem 1.2rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.14);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(241, 251, 236, 0.18);
+  border: 1px solid rgba(241, 251, 236, 0.35);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.75rem;
@@ -67,25 +67,25 @@
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: #fff;
+  background: linear-gradient(135deg, var(--luxe-amber, #ff771b), #d85f18);
+  color: var(--luxe-cream, #fff);
   padding: 0.85rem 1.75rem;
   border-radius: 999px;
   font-weight: 600;
   transition: transform 200ms ease, box-shadow 200ms ease;
-  box-shadow: 0 18px 35px rgba(66, 99, 235, 0.32);
+  box-shadow: 0 18px 35px rgba(255, 119, 27, 0.28);
 }
 
 .hero-primary:hover {
   transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 22px 42px rgba(66, 99, 235, 0.45);
+  box-shadow: 0 22px 42px rgba(255, 119, 27, 0.38);
 }
 
 .hero-stats {
-  background: rgba(12, 13, 17, 0.55);
+  background: rgba(19, 53, 31, 0.55);
   padding: 1rem 1.25rem;
   border-radius: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(241, 251, 236, 0.35);
   backdrop-filter: blur(16px);
   min-width: min(100%, 18rem);
 }
@@ -104,7 +104,7 @@
 
 .hero-stat__label {
   font-size: 0.82rem;
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(241, 251, 236, 0.8);
   letter-spacing: 0.02em;
 }
 
@@ -115,11 +115,11 @@
 }
 
 .filter-card {
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(255, 255, 255, 0.92);
   border-radius: 1.75rem;
   padding: clamp(1.5rem, 4vw, 2.75rem);
-  box-shadow: 0 24px 60px rgba(57, 76, 135, 0.15);
-  border: 1px solid rgba(170, 180, 210, 0.25);
+  box-shadow: var(--luxe-soft-shadow, 0 24px 60px rgba(19, 53, 31, 0.18));
+  border: 1px solid rgba(32, 71, 38, 0.12);
   backdrop-filter: blur(18px);
 }
 
@@ -133,11 +133,11 @@
 .filter-card__header h2 {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #1f2335;
+  color: var(--luxe-forest-800, #1f3923);
 }
 
 .filter-card__header p {
-  color: #4a4f63;
+  color: rgba(32, 71, 38, 0.7);
   max-width: 32rem;
   line-height: 1.6;
 }
@@ -150,7 +150,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #3c4054;
+  color: rgba(32, 71, 38, 0.8);
   flex-wrap: wrap;
 }
 
@@ -163,15 +163,15 @@
 }
 
 .legend-dot--ongoing {
-  background: linear-gradient(135deg, #66d06d, #4db857);
+  background: linear-gradient(135deg, rgba(32, 71, 38, 0.9), rgba(47, 118, 68, 0.8));
 }
 
 .legend-dot--upcoming {
-  background: linear-gradient(135deg, #f8d57e, #f6b94f);
+  background: linear-gradient(135deg, rgba(255, 119, 27, 0.85), rgba(255, 162, 82, 0.85));
 }
 
 .legend-dot--completed {
-  background: linear-gradient(135deg, #7da2ff, #586bff);
+  background: linear-gradient(135deg, rgba(216, 231, 211, 1), rgba(164, 201, 157, 0.95));
 }
 
 .filter-grid {
@@ -191,24 +191,24 @@
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #4b4f6e;
+  color: rgba(32, 71, 38, 0.65);
 }
 
 .filter-select {
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 0.85rem;
-  border: 1px solid rgba(98, 115, 183, 0.35);
-  background: rgba(255, 255, 255, 0.85);
-  color: #1f2335;
+  border: 1px solid rgba(32, 71, 38, 0.22);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--luxe-forest-900, #1a2f1e);
   font-weight: 500;
   transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
 .filter-select:focus {
   outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(66, 99, 235, 0.2);
+  border-color: var(--luxe-amber, #ff771b);
+  box-shadow: 0 0 0 3px rgba(255, 119, 27, 0.2);
 }
 
 .filter-actions {
@@ -236,26 +236,26 @@
 }
 
 .filter-button--primary {
-  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: #fff;
-  box-shadow: 0 18px 40px rgba(58, 83, 210, 0.22);
+  background: linear-gradient(135deg, var(--luxe-amber, #ff771b), #d85f18);
+  color: var(--luxe-cream, #fff);
+  box-shadow: 0 18px 40px rgba(255, 119, 27, 0.25);
   border: none;
 }
 
 .filter-button--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 42px rgba(58, 83, 210, 0.32);
+  box-shadow: 0 20px 42px rgba(255, 119, 27, 0.35);
 }
 
 .filter-button--ghost {
-  background: rgba(255, 255, 255, 0.92);
-  color: #1f2335;
-  border: 1px solid rgba(98, 115, 183, 0.4);
+  background: rgba(241, 251, 236, 0.92);
+  color: var(--luxe-forest-900, #1a2f1e);
+  border: 1px solid rgba(32, 71, 38, 0.25);
 }
 
 .filter-button--ghost:hover {
   transform: translateY(-2px);
-  background: rgba(98, 115, 183, 0.12);
+  background: rgba(32, 71, 38, 0.12);
 }
 
 .projects-section {
@@ -272,12 +272,12 @@
 .projects-header h2 {
   font-size: clamp(2rem, 4vw, 2.8rem);
   font-weight: 700;
-  color: #111322;
+  color: var(--luxe-forest-900, #132b18);
 }
 
 .projects-header p {
   max-width: 32rem;
-  color: #535876;
+  color: rgba(32, 71, 38, 0.68);
   line-height: 1.7;
 }
 
@@ -285,12 +285,12 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  background: rgba(88, 108, 255, 0.12);
+  background: rgba(255, 119, 27, 0.12);
   border-radius: 999px;
   padding: 0.35rem 1.1rem;
   font-size: 0.85rem;
   font-weight: 600;
-  color: #3b48c5;
+  color: var(--luxe-amber, #ff771b);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -309,15 +309,15 @@
 .project-card {
   border-radius: 1.75rem;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 24px 48px rgba(43, 54, 126, 0.14);
-  border: 1px solid rgba(172, 183, 224, 0.28);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 24px 48px rgba(19, 53, 31, 0.16);
+  border: 1px solid rgba(32, 71, 38, 0.12);
   transition: transform 220ms ease, box-shadow 220ms ease;
 }
 
 .project-card:hover {
   transform: translateY(-6px);
-  box-shadow: 0 32px 64px rgba(43, 54, 126, 0.2);
+  box-shadow: 0 32px 64px rgba(19, 53, 31, 0.22);
 }
 
 .project-card__link {
@@ -348,7 +348,7 @@
 .project-card__overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(18, 21, 34, 0.05) 0%, rgba(18, 21, 34, 0.55) 100%);
+  background: linear-gradient(180deg, rgba(19, 53, 31, 0.05) 0%, rgba(19, 53, 31, 0.6) 100%);
   opacity: 0.85;
 }
 
@@ -369,11 +369,11 @@
   gap: 0.35rem;
   padding: 0.4rem 0.75rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(241, 251, 236, 0.92);
   font-size: 0.8rem;
   font-weight: 600;
-  color: #2d3154;
-  box-shadow: 0 12px 24px rgba(32, 40, 94, 0.15);
+  color: var(--luxe-forest-800, #1f3923);
+  box-shadow: 0 12px 24px rgba(32, 71, 38, 0.15);
 }
 
 .project-card__body {
@@ -387,11 +387,11 @@
 .project-card__body h3 {
   font-size: 1.35rem;
   font-weight: 700;
-  color: #1a1c2e;
+  color: var(--luxe-forest-900, #132b18);
 }
 
 .project-card__body p {
-  color: #4a4f69;
+  color: rgba(32, 71, 38, 0.65);
   line-height: 1.5;
 }
 
@@ -400,7 +400,7 @@
   align-items: center;
   gap: 0.35rem;
   font-weight: 600;
-  color: var(--accent);
+  color: var(--luxe-amber, #ff771b);
   transition: transform 200ms ease;
 }
 
@@ -412,10 +412,10 @@
   grid-column: 1 / -1;
   text-align: center;
   padding: 4rem 2rem;
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(241, 251, 236, 0.95);
   border-radius: 1.5rem;
-  border: 1px dashed rgba(88, 108, 255, 0.35);
-  color: #3a3f61;
+  border: 1px dashed rgba(32, 71, 38, 0.28);
+  color: rgba(32, 71, 38, 0.75);
   font-weight: 600;
 }
 
@@ -426,15 +426,15 @@
 }
 
 .projects-cta__card {
-  background: linear-gradient(135deg, #121527, #1e2442);
+  background: linear-gradient(135deg, rgba(19, 53, 31, 0.96), rgba(32, 71, 38, 0.9));
   border-radius: 2.2rem;
   padding: clamp(2.4rem, 6vw, 3.8rem);
   max-width: 960px;
   width: min(100%, 960px);
-  color: #f6f7ff;
+  color: rgba(241, 251, 236, 0.95);
   text-align: center;
-  box-shadow: 0 38px 80px rgba(20, 27, 60, 0.45);
-  border: 1px solid rgba(105, 132, 255, 0.35);
+  box-shadow: 0 38px 80px rgba(19, 53, 31, 0.4);
+  border: 1px solid rgba(241, 251, 236, 0.22);
 }
 
 .projects-cta__card h2 {
@@ -447,7 +447,7 @@
   max-width: 40rem;
   margin: 0 auto 2rem;
   line-height: 1.7;
-  color: rgba(246, 247, 255, 0.82);
+  color: rgba(241, 251, 236, 0.78);
 }
 
 .projects-cta__action {
@@ -455,17 +455,17 @@
   align-items: center;
   gap: 0.6rem;
   background: rgba(255, 255, 255, 0.92);
-  color: #1e2442;
+  color: var(--luxe-forest-900, #132b18);
   padding: 0.85rem 1.9rem;
   border-radius: 999px;
   font-weight: 600;
   transition: transform 200ms ease, box-shadow 200ms ease;
-  box-shadow: 0 18px 42px rgba(14, 24, 69, 0.28);
+  box-shadow: 0 18px 42px rgba(32, 71, 38, 0.22);
 }
 
 .projects-cta__action:hover {
   transform: translateY(-3px);
-  box-shadow: 0 24px 52px rgba(14, 24, 69, 0.38);
+  box-shadow: 0 24px 52px rgba(32, 71, 38, 0.3);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- restyle the projects page to use the Tailwind brand palette for backgrounds, buttons, and supporting accents
- refresh all contact page sections with the brand greens and amber plus supporting typography tones
- update contact markup to reference the new color tokens directly in key headings

## Testing
- npm run build *(fails: existing gallery-page.component.html has unexpected closing tag errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e33bc890548323b6365cdbe5840dc5