### PR TITLE
Update gallery hero to match about page styling

### DIFF
--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.css
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.css
@@ -4,183 +4,60 @@
 
 .gallery-hero {
   position: relative;
-  min-height: clamp(420px, 60vh, 600px);
-  border-radius: clamp(1.5rem, 4vw, 3rem);
-  overflow: hidden;
-  background: #060814;
-  display: grid;
-  align-items: stretch;
+  background: #030712;
+  color: var(--light, #f9fafb);
+  isolation: isolate;
 }
 
-.gallery-hero__background {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
+.gallery-hero__bg {
+  transition: transform 0.6s ease;
 }
 
-.gallery-hero__media {
-  position: absolute;
-  inset: -12% -6% 0;
-  will-change: transform;
-  transition: transform 0.35s ease;
-  z-index: 1;
-}
-
-.gallery-hero__media img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: saturate(105%) contrast(105%);
-  transform: scale(1.05);
-}
-
-.gallery-hero__gradient {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(130deg, rgba(13, 17, 38, 0.85), rgba(6, 8, 20, 0.92));
-  z-index: 2;
-}
-
-.gallery-hero__glow {
-  position: absolute;
-  width: 22rem;
-  height: 22rem;
-  filter: blur(70px);
-  opacity: 0.65;
-  z-index: 0;
+.gallery-hero__overlay {
   pointer-events: none;
 }
 
-.gallery-hero__glow--left {
-  top: 12%;
-  left: -5%;
-  background: radial-gradient(circle, rgba(100, 115, 255, 0.75), transparent 70%);
-}
-
-.gallery-hero__glow--right {
-  bottom: -6%;
-  right: -3%;
-  background: radial-gradient(circle, rgba(255, 122, 84, 0.65), transparent 70%);
-}
-
-.gallery-hero__content {
-  position: relative;
-  z-index: 3;
-  display: grid;
-  gap: 1.25rem;
-  padding: clamp(2.5rem, 8vw, 5rem) clamp(1.75rem, 8vw, 5rem);
-  color: #f8f9ff;
-  max-width: 680px;
-}
-
-.gallery-hero__badge {
-  width: fit-content;
-  padding: 0.35rem 1.1rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.16);
-  backdrop-filter: blur(18px);
-  font-size: 0.75rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
-.gallery-hero__title {
-  font-size: clamp(2.75rem, 2rem + 2.5vw, 4rem);
-  font-weight: 600;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-}
-
-.gallery-hero__subtitle {
-  font-size: clamp(1.05rem, 0.9rem + 0.8vw, 1.35rem);
-  color: rgba(241, 244, 255, 0.78);
-  line-height: 1.7;
-}
-
-.gallery-hero__breadcrumb {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-size: 0.95rem;
-  color: rgba(241, 244, 255, 0.7);
-}
-
-.gallery-hero__breadcrumb-link {
-  color: inherit;
-  text-decoration: none;
-  position: relative;
-}
-
-.gallery-hero__breadcrumb-link::after {
-  content: '';
+.gallery-hero__accent {
   position: absolute;
-  left: 0;
-  bottom: -0.15rem;
-  width: 100%;
-  height: 1px;
-  background: rgba(255, 255, 255, 0.4);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.3s ease;
+  border-radius: 9999px;
+  filter: blur(0);
+  opacity: 0.65;
+  pointer-events: none;
+  mix-blend-mode: screen;
 }
 
-.gallery-hero__breadcrumb-link:hover::after,
-.gallery-hero__breadcrumb-link:focus-visible::after {
-  transform: scaleX(1);
+.gallery-hero__accent--one {
+  top: -6rem;
+  right: -5rem;
+  width: clamp(16rem, 25vw, 21rem);
+  height: clamp(16rem, 25vw, 21rem);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 119, 27, 0.45), transparent 70%);
+  animation: float 14s ease-in-out infinite;
 }
 
-.gallery-hero__breadcrumb-link:focus-visible {
-  outline: 2px solid rgba(160, 172, 255, 0.6);
-  outline-offset: 3px;
-  border-radius: 4px;
+.gallery-hero__accent--two {
+  bottom: -5rem;
+  left: -6rem;
+  width: clamp(18rem, 32vw, 28rem);
+  height: clamp(18rem, 32vw, 28rem);
+  background: radial-gradient(circle at 70% 70%, rgba(56, 189, 248, 0.35), transparent 65%);
+  animation: float 16s ease-in-out infinite reverse;
 }
 
-.gallery-hero__breadcrumb-current {
-  color: rgba(241, 244, 255, 0.9);
-}
-
-.gallery-hero__meta {
-  display: grid;
-  gap: 0.85rem;
-  max-width: 420px;
-}
-
-@media (min-width: 768px) {
-  .gallery-hero__meta {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@keyframes float {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
   }
-}
-
-.gallery-hero__meta-card {
-  padding: 1rem 1.25rem;
-  border-radius: 1rem;
-  background: rgba(10, 13, 30, 0.6);
-  backdrop-filter: blur(22px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.gallery-hero__meta-eyebrow {
-  display: block;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  color: rgba(201, 208, 255, 0.6);
-  margin-bottom: 0.45rem;
-}
-
-.gallery-hero__meta-value {
-  font-size: 1rem;
-  font-weight: 600;
-  color: rgba(248, 249, 255, 0.94);
+  50% {
+    transform: translate3d(10px, -14px, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
 }
 
 @media (max-width: 768px) {
   .gallery-hero {
     border-radius: clamp(1.1rem, 4vw, 2rem);
-  }
-
-  .gallery-hero__background {
-    opacity: 0.92;
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
@@ -1,39 +1,71 @@
-<section class="gallery-hero" aria-labelledby="galleryHeroTitle">
-  <div class="gallery-hero__background">
-    <div
-      class="gallery-hero__media"
-      [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.2) + 'px)' }"
-    >
-      <img
-        src="/images/banner/banner-3.png"
-        alt="Gallery showcase"
-        loading="lazy"
-      />
-    </div>
-    <div class="gallery-hero__gradient"></div>
-    <div class="gallery-hero__glow gallery-hero__glow--left"></div>
-    <div class="gallery-hero__glow gallery-hero__glow--right"></div>
-  </div>
+<section
+  class="gallery-hero relative w-full min-h-[70vh] overflow-hidden rounded-[clamp(1.5rem,4vw,3rem)] md:min-h-[80vh]"
+  aria-labelledby="galleryHeroTitle"
+>
+  <div
+    class="gallery-hero__bg absolute top-0 left-0 w-full h-[120%] bg-cover bg-center transform-gpu will-change-transform"
+    style="background-image: url('/images/banner/banner-3.png')"
+    [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.3 - 60) + 'px)' }"
+  ></div>
 
-  <div class="gallery-hero__content">
-    <div class="gallery-hero__badge">Immersive showcase</div>
-    <h1 class="gallery-hero__title" id="galleryHeroTitle">Gallery</h1>
-    <p class="gallery-hero__subtitle">
-      Discover the crafted stories, moods, and spaces that define AS Haven.
-    </p>
-    <nav class="gallery-hero__breadcrumb" aria-label="Breadcrumb">
-      <a routerLink="/" class="gallery-hero__breadcrumb-link">Home</a>
-      <span aria-hidden="true" class="gallery-hero__breadcrumb-separator">/</span>
-      <span class="gallery-hero__breadcrumb-current">Gallery</span>
-    </nav>
-    <div class="gallery-hero__meta">
-      <div class="gallery-hero__meta-card">
-        <span class="gallery-hero__meta-eyebrow">Curated visions</span>
-        <span class="gallery-hero__meta-value">Architectural artistry</span>
-      </div>
-      <div class="gallery-hero__meta-card">
-        <span class="gallery-hero__meta-eyebrow">Experience</span>
-        <span class="gallery-hero__meta-value">Still &amp; motion stories</span>
+  <div class="gallery-hero__overlay absolute inset-0 bg-gradient-to-r from-[#030712]/90 via-[#030712]/75 to-[#030712]/40"></div>
+
+  <div class="gallery-hero__accent gallery-hero__accent--one"></div>
+  <div class="gallery-hero__accent gallery-hero__accent--two"></div>
+
+  <div class="relative z-10 flex h-full w-full items-center">
+    <div class="mx-auto flex h-full w-[90%] max-w-6xl flex-col justify-center py-16 md:py-24">
+      <div class="grid items-center gap-12 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <div class="space-y-6 text-center lg:text-left">
+          <span class="inline-flex items-center justify-center gap-2 text-[0.7rem] uppercase tracking-[0.6em] text-white/70 lg:justify-start">
+            <span class="h-2 w-2 rounded-full bg-accent"></span>
+            Immersive showcase
+          </span>
+          <h1 class="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl" id="galleryHeroTitle">
+            Gallery
+          </h1>
+          <p class="mx-auto max-w-2xl text-base text-white/80 sm:text-lg lg:mx-0">
+            Discover the crafted stories, moods, and spaces that define AS Haven.
+          </p>
+          <nav class="flex items-center justify-center gap-3 text-sm text-white/60 lg:justify-start" aria-label="Breadcrumb">
+            <a routerLink="/" class="relative text-white/70 transition-colors duration-300 hover:text-white focus-visible:text-white">
+              Home
+            </a>
+            <span aria-hidden="true" class="text-white/40">/</span>
+            <span class="text-white">Gallery</span>
+          </nav>
+          <div class="flex flex-col items-center gap-4 sm:flex-row lg:justify-start">
+            <a
+              href="#projectGallery"
+              class="group inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-7 py-3 text-xs font-semibold uppercase tracking-[0.35em] text-white backdrop-blur transition duration-300 hover:bg-white hover:text-dark"
+            >
+              Browse Collection
+              <i class="ri-arrow-right-up-line text-base transition duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-1"></i>
+            </a>
+            <div class="inline-flex items-center gap-3 rounded-full bg-white/5 px-5 py-3 text-white/80 backdrop-blur-xl ring-1 ring-white/10">
+              <span class="h-2.5 w-2.5 rounded-full bg-accent shadow-[0_0_15px_rgba(255,119,27,0.6)] animate-pulse"></span>
+              <span class="text-xs uppercase tracking-[0.3em]">Stills • Motion • Atmospheres</span>
+            </div>
+          </div>
+        </div>
+        <div class="space-y-5">
+          <div class="rounded-3xl border border-white/10 bg-white/10 p-6 text-left text-white shadow-2xl backdrop-blur-2xl">
+            <h3 class="mb-3 text-sm font-semibold uppercase tracking-[0.4em] text-white/70">Curated perspectives</h3>
+            <p class="text-sm leading-relaxed text-white/80">
+              Step into the ambience of each development through cinematic stills and motion. Every capture highlights the dialogue between architecture, light, and landscape.
+            </p>
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div class="rounded-2xl bg-white/10 px-4 py-6 text-center text-white backdrop-blur-xl ring-1 ring-white/15">
+              <span class="block text-xs uppercase tracking-[0.4em] text-white/60">Featured</span>
+              <span class="mt-2 block text-xl font-semibold">Architectural artistry</span>
+            </div>
+            <div class="rounded-2xl bg-white/10 px-4 py-6 text-center text-white backdrop-blur-xl ring-1 ring-white/15">
+              <span class="block text-xs uppercase tracking-[0.4em] text-white/60">Experience</span>
+              <span class="mt-2 block text-xl font-semibold">Still &amp; motion stories</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.ts
@@ -9,7 +9,7 @@ import { RouterModule } from '@angular/router';
   templateUrl: './gallery-hero.component.html',
   styleUrl: './gallery-hero.component.css',
 })
-export class ContactHeroComponent {
+export class GalleryHeroComponent {
   scrollY = 0;
 
   @HostListener('window:scroll', ['$event'])

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.ts
@@ -9,13 +9,13 @@ import {
 import { CommonModule } from '@angular/common';
 import { GalleryItem, GalleryService } from '../../services/gallery.service';
 import { environment } from '../../environments/environment';
-import { ContactHeroComponent } from './gallery-hero/gallery-hero.component';
+import { GalleryHeroComponent } from './gallery-hero/gallery-hero.component';
 import { AnimationService } from '../../services/animation.service';
 
 @Component({
   selector: 'app-gallery-page',
   standalone: true,
-  imports: [CommonModule, ContactHeroComponent],
+  imports: [CommonModule, GalleryHeroComponent],
   templateUrl: './gallery-page.component.html',
   styleUrls: ['./gallery-page.component.css'],
 })


### PR DESCRIPTION
## Summary
- restyle the gallery hero layout to reuse the dark gradient palette and glowing accents from the about page
- reorganize the hero content with Tailwind utility classes, refreshed copy, and matching call-to-action styling
- rename the gallery hero component class and update the gallery page import for consistency

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e359aca1348323b8b07f7134373acd