### PR TITLE
Align dashboard inner pages with overview theme

### DIFF
--- a/frontend/ashaven-ui/src/app/features/client/client.component.html
+++ b/frontend/ashaven-ui/src/app/features/client/client.component.html
@@ -1,8 +1,8 @@
-<div class="p-6 bg-light text-dark">
+<div class="p-6 bg-light text-dark luxe-dashboard-surface">
   <h2 class="text-2xl font-semibold mb-4">Contact Submissions</h2>
 
   <!-- Error Message -->
-  <div *ngIf="errorMessage" class="mb-4 p-4 bg-red-100 text-red-700 rounded-lg">
+  <div *ngIf="errorMessage" class="luxe-dashboard-alert mb-4">
     {{ errorMessage }}
   </div>
 

--- a/frontend/ashaven-ui/src/app/features/consultant/consultant-index/consultant-index.component.html
+++ b/frontend/ashaven-ui/src/app/features/consultant/consultant-index/consultant-index.component.html
@@ -21,7 +21,7 @@
 
   <!-- Consultants Table -->
   <div
-    class="relative overflow-x-auto bg-white rounded-lg shadow-md fade-up animate"
+    class="relative overflow-x-auto bg-white rounded-lg shadow-md fade-up animate luxe-dashboard-surface"
   >
     <table class="min-w-full divide-y ">
       <thead class="bg-accentLight">

--- a/frontend/ashaven-ui/src/app/features/dashboard/dashboard.component.css
+++ b/frontend/ashaven-ui/src/app/features/dashboard/dashboard.component.css
@@ -264,6 +264,21 @@
   flex: 1;
   overflow-y: auto;
   padding: clamp(2rem, 4vw, 3rem);
+  position: relative;
+  z-index: 0;
+}
+
+.luxe-dashboard__content::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 119, 27, 0.14), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(114, 255, 175, 0.08), transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(255, 119, 27, 0.08), transparent 65%);
+  pointer-events: none;
+  opacity: 0.65;
+  z-index: -1;
 }
 
 .luxe-dashboard__modal {
@@ -381,4 +396,149 @@
   .luxe-dashboard__search input {
     width: 140px;
   }
+}
+
+:host ::ng-deep .luxe-dashboard-surface,
+:host ::ng-deep .luxe-dashboard__content .bg-white,
+:host ::ng-deep .luxe-dashboard__content .bg-light,
+:host ::ng-deep .luxe-dashboard__content .bg-gray-50,
+:host ::ng-deep .luxe-dashboard__content .dark\:bg-gray-700,
+:host ::ng-deep .luxe-dashboard__content .dark\:bg-gray-800,
+:host ::ng-deep .luxe-dashboard__content .dark\:bg-gray-900 {
+  background: rgba(16, 38, 24, 0.78) !important;
+  border: 1px solid rgba(241, 251, 236, 0.1) !important;
+  box-shadow: var(--luxe-soft-shadow);
+  backdrop-filter: blur(14px);
+  border-radius: var(--luxe-radius);
+}
+
+:host ::ng-deep .luxe-dashboard__content [class*='bg-[var(--white)]'] {
+  background: rgba(16, 38, 24, 0.78) !important;
+  border: 1px solid rgba(241, 251, 236, 0.1) !important;
+  box-shadow: var(--luxe-soft-shadow);
+  backdrop-filter: blur(14px);
+  border-radius: var(--luxe-radius);
+}
+
+:host ::ng-deep .luxe-dashboard__content .bg-accentLight,
+:host ::ng-deep .luxe-dashboard__content .bg-gray-100,
+:host ::ng-deep .luxe-dashboard__content .bg-dark {
+  background: rgba(255, 119, 27, 0.16) !important;
+  color: var(--luxe-cream) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .shadow,
+:host ::ng-deep .luxe-dashboard__content .shadow-md,
+:host ::ng-deep .luxe-dashboard__content .shadow-lg {
+  box-shadow: var(--luxe-soft-shadow) !important;
+  border-radius: var(--luxe-radius);
+  border: 1px solid rgba(241, 251, 236, 0.1);
+}
+
+:host ::ng-deep .luxe-dashboard__content .text-dark,
+:host ::ng-deep .luxe-dashboard__content .text-gray-900,
+:host ::ng-deep .luxe-dashboard__content .text-gray-800,
+:host ::ng-deep .luxe-dashboard__content .text-gray-700,
+:host ::ng-deep .luxe-dashboard__content .text-gray-600,
+:host ::ng-deep .luxe-dashboard__content .text-gray-500,
+:host ::ng-deep .luxe-dashboard__content .text-black,
+:host ::ng-deep .luxe-dashboard__content .dark\:text-white {
+  color: rgba(241, 251, 236, 0.88) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content [class*='text-[var(--dark)]'],
+:host ::ng-deep .luxe-dashboard__content [class*='text-[var(--gray)]'],
+:host ::ng-deep .luxe-dashboard__content [class*='text-[var(--gray-dark)]'] {
+  color: rgba(241, 251, 236, 0.75) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content table {
+  color: rgba(241, 251, 236, 0.88);
+  border-collapse: collapse;
+  width: 100%;
+}
+
+:host ::ng-deep .luxe-dashboard__content h1,
+:host ::ng-deep .luxe-dashboard__content h2,
+:host ::ng-deep .luxe-dashboard__content h3,
+:host ::ng-deep .luxe-dashboard__content h4,
+:host ::ng-deep .luxe-dashboard__content h5,
+:host ::ng-deep .luxe-dashboard__content h6 {
+  font-family: 'Playfair Display', serif;
+  letter-spacing: 0.04em;
+  color: var(--luxe-cream);
+}
+
+:host ::ng-deep .luxe-dashboard__content p,
+:host ::ng-deep .luxe-dashboard__content span,
+:host ::ng-deep .luxe-dashboard__content label {
+  color: rgba(241, 251, 236, 0.75);
+}
+
+:host ::ng-deep .luxe-dashboard__content thead {
+  background: rgba(16, 38, 24, 0.9) !important;
+  color: rgba(241, 251, 236, 0.72) !important;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+:host ::ng-deep .luxe-dashboard__content th,
+:host ::ng-deep .luxe-dashboard__content td {
+  border-color: rgba(241, 251, 236, 0.08) !important;
+  padding: 1rem 1.25rem;
+}
+
+:host ::ng-deep .luxe-dashboard__content tbody tr:hover {
+  background: rgba(255, 119, 27, 0.12) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .bg-red-100,
+:host ::ng-deep .luxe-dashboard__content .bg-red-500\/20 {
+  background: rgba(255, 120, 120, 0.16) !important;
+  color: #ffb4a4 !important;
+  border: 1px solid rgba(255, 120, 120, 0.25) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .bg-green-100,
+:host ::ng-deep .luxe-dashboard__content .bg-green-500\/20 {
+  background: rgba(114, 255, 175, 0.14) !important;
+  color: #72ffaf !important;
+  border: 1px solid rgba(114, 255, 175, 0.25) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .text-red-500,
+:host ::ng-deep .luxe-dashboard__content .text-red-600,
+:host ::ng-deep .luxe-dashboard__content .text-red-700 {
+  color: #ffb4a4 !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .text-green-500,
+:host ::ng-deep .luxe-dashboard__content .text-green-600 {
+  color: #72ffaf !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .text-blue-700,
+:host ::ng-deep .luxe-dashboard__content .text-cyan-600 {
+  color: #8edcff !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .border,
+:host ::ng-deep .luxe-dashboard__content .border-gray-200,
+:host ::ng-deep .luxe-dashboard__content .border-lightDark,
+:host ::ng-deep .luxe-dashboard__content .border-light,
+:host ::ng-deep .luxe-dashboard__content .divide-y,
+:host ::ng-deep .luxe-dashboard__content .divide-lightDark {
+  border-color: rgba(241, 251, 236, 0.08) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .divide-y > :not([hidden]) ~ :not([hidden]) {
+  border-color: rgba(241, 251, 236, 0.08) !important;
+}
+
+:host ::ng-deep .luxe-dashboard__content .luxe-dashboard-alert {
+  padding: 1rem 1.4rem;
+  border-radius: var(--luxe-radius-sm);
+  border: 1px solid rgba(255, 119, 27, 0.35);
+  background: rgba(255, 119, 27, 0.12);
+  color: var(--luxe-cream);
 }

--- a/frontend/ashaven-ui/src/app/features/faq/faq.component.html
+++ b/frontend/ashaven-ui/src/app/features/faq/faq.component.html
@@ -24,7 +24,7 @@
       <!-- Add FAQ Form -->
       <div
         *ngIf="newFaq"
-        class="bg-[var(--white)] rounded-xl shadow-lg p-5 mb-4"
+        class="bg-[var(--white)] rounded-xl shadow-lg p-5 mb-4 luxe-dashboard-surface"
       >
         <ng-container *ngIf="newFaq">
           <input
@@ -64,7 +64,7 @@
     <div class="space-y-4">
       <div
         *ngFor="let faq of faqs"
-        class="faq-item bg-[var(--white)] rounded-xl shadow-lg p-5"
+        class="faq-item bg-[var(--white)] rounded-xl shadow-lg p-5 luxe-dashboard-surface"
       >
         <!-- Edit FAQ Form -->
         <div *ngIf="editingFaq && editingFaq.id === faq.id">

--- a/frontend/ashaven-ui/src/app/features/gallery/gallery.component.html
+++ b/frontend/ashaven-ui/src/app/features/gallery/gallery.component.html
@@ -17,7 +17,7 @@
       class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-50"
     >
       <div class="relative p-4 w-full max-w-2xl h-full md:h-auto">
-        <div class="relative p-4 bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
+        <div class="relative p-4 bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5 luxe-dashboard-surface">
           <div class="flex justify-between items-center pb-4 mb-4 rounded-t border-b sm:mb-5 dark:border-gray-600">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Add Gallery</h3>
             <button
@@ -131,7 +131,7 @@
       class="fixed top-0 right-0 left-0 z-50 flex justify-center items-center w-full h-[calc(100%-1rem)] max-h-full bg-black bg-opacity-50"
     >
       <div class="relative p-4 w-full max-w-2xl h-full md:h-auto">
-        <div class="relative p-4 bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5">
+        <div class="relative p-4 bg-white rounded-lg shadow dark:bg-gray-800 sm:p-5 luxe-dashboard-surface">
           <div class="flex justify-between items-center pb-4 mb-4 rounded-t border-b sm:mb-5 dark:border-gray-600">
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Edit Gallery</h3>
             <button

--- a/frontend/ashaven-ui/src/app/features/offers/offers-index/offers-index.component.html
+++ b/frontend/ashaven-ui/src/app/features/offers/offers-index/offers-index.component.html
@@ -18,7 +18,7 @@
     <app-offer-form [offer]="selectedOffer" mode="edit" (close)="closeModal()" (saved)="onOfferSaved()"></app-offer-form>
   </div>
 
-  <div class="relative overflow-x-auto shadow-md">
+  <div class="relative overflow-x-auto shadow-md luxe-dashboard-surface">
     <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
       <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
         <tr>

--- a/frontend/ashaven-ui/src/app/features/teams/teams-index/teams-index.component.html
+++ b/frontend/ashaven-ui/src/app/features/teams/teams-index/teams-index.component.html
@@ -21,7 +21,7 @@
 
   <!-- Teams Table -->
   <div
-    class="relative overflow-x-auto bg-white rounded-lg shadow-md fade-up animate"
+    class="relative overflow-x-auto bg-white rounded-lg shadow-md fade-up animate luxe-dashboard-surface"
   >
     <table class="min-w-full divide-y divide-lightDark">
       <thead class="bg-accentLight">

--- a/frontend/ashaven-ui/src/app/features/testimonials/testimonials-index/testimonials-index.component.html
+++ b/frontend/ashaven-ui/src/app/features/testimonials/testimonials-index/testimonials-index.component.html
@@ -23,7 +23,7 @@
   </div>
 
   <!-- Testimonials Table -->
-  <div class="relative overflow-x-auto shadow-lg rounded-lg">
+  <div class="relative overflow-x-auto shadow-lg rounded-lg luxe-dashboard-surface">
     <table class="w-full text-sm text-left text-lightDark">
       <thead class="text-xs text-dark uppercase bg-accentLight border-b">
         <tr>


### PR DESCRIPTION
## Summary
- extend the dashboard layout styles with shared glassmorphism rules so every child view inherits the overview gradient, typography, and surface treatments
- tag dashboard tables, forms, and alerts with the new luxe-dashboard-surface utility for consistent background handling across clients, teams, consultants, testimonials, offers, gallery, and FAQ pages
- standardize inline alert styling in the contacts page to use the shared dashboard alert presentation

## Testing
- npm run lint *(fails: script missing in project)*

------
https://chatgpt.com/codex/tasks/task_e_68e37e9766ac83239cb73d0987f7449f