### PR TITLE
Align front-end page layouts to 85% viewport width

### DIFF
--- a/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
+++ b/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
@@ -78,17 +78,9 @@
 .neo-hero__container {
   position: relative;
   z-index: 2;
-  width: min(92vw, 1200px);
-  margin: 0 auto;
   height: 100%;
   display: flex;
   align-items: center;
-}
-
-@media (min-width: 1024px) {
-  .neo-hero__container {
-    width: min(85vw, 1200px);
-  }
 }
 
 .neo-hero__grid {

--- a/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
+++ b/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
@@ -78,11 +78,17 @@
 .neo-hero__container {
   position: relative;
   z-index: 2;
-  max-width: 1200px;
+  width: min(92vw, 1200px);
   margin: 0 auto;
   height: 100%;
   display: flex;
   align-items: center;
+}
+
+@media (min-width: 1024px) {
+  .neo-hero__container {
+    width: min(85vw, 1200px);
+  }
 }
 
 .neo-hero__grid {

--- a/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.html
+++ b/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.html
@@ -15,7 +15,7 @@
     <div class="neo-hero__pattern"></div>
   </div>
 
-  <div *ngIf="activeSlide as active" class="neo-hero__container">
+  <div *ngIf="activeSlide as active" class="neo-hero__container page-width">
     <div class="neo-hero__grid">
       <aside class="neo-hero__sidebar">
         <span class="neo-hero__eyebrow">Avant-garde living</span>

--- a/frontend/ashaven-ui/src/app/components/project-explore/project-explore.component.html
+++ b/frontend/ashaven-ui/src/app/components/project-explore/project-explore.component.html
@@ -1,33 +1,35 @@
 <section class="neo-section" id="projects">
-  <div class="neo-section__header">
-    <span class="neo-section__tag">Curated Collection</span>
-    <h2 class="neo-section__title">Explore Our Signature Projects</h2>
-    <p class="neo-section__subtitle">
-      Discover the communities, residences, and visionary spaces defining AS Haven’s next chapter.
-    </p>
-  </div>
+  <div class="neo-section__inner">
+    <div class="neo-section__header">
+      <span class="neo-section__tag">Curated Collection</span>
+      <h2 class="neo-section__title">Explore Our Signature Projects</h2>
+      <p class="neo-section__subtitle">
+        Discover the communities, residences, and visionary spaces defining AS Haven’s next chapter.
+      </p>
+    </div>
 
-  <div class="neo-projects-grid">
-    <article
-      *ngFor="let item of projects"
-      class="neo-project-card"
-      (mousemove)="onMouseMove($event)"
-      (mouseleave)="onMouseLeave($event)"
-    >
-      <a
-        [routerLink]="item.route"
-        [queryParams]="{ category: item.title.split(' ')[0] }"
-        class="neo-project-card__inner"
+    <div class="neo-projects-grid">
+      <article
+        *ngFor="let item of projects"
+        class="neo-project-card"
+        (mousemove)="onMouseMove($event)"
+        (mouseleave)="onMouseLeave($event)"
       >
-        <div class="neo-project-card__halo" aria-hidden="true"></div>
-        <div class="neo-project-card__media">
-          <img [src]="item.image" [alt]="item.title + ' icon'" />
-        </div>
-        <div class="neo-project-card__content">
-          <h3>{{ item.title }}</h3>
-          <p>Explore ↗</p>
-        </div>
-      </a>
-    </article>
+        <a
+          [routerLink]="item.route"
+          [queryParams]="{ category: item.title.split(' ')[0] }"
+          class="neo-project-card__inner"
+        >
+          <div class="neo-project-card__halo" aria-hidden="true"></div>
+          <div class="neo-project-card__media">
+            <img [src]="item.image" [alt]="item.title + ' icon'" />
+          </div>
+          <div class="neo-project-card__content">
+            <h3>{{ item.title }}</h3>
+            <p>Explore ↗</p>
+          </div>
+        </a>
+      </article>
+    </div>
   </div>
 </section>

--- a/frontend/ashaven-ui/src/app/components/slider/slider.component.html
+++ b/frontend/ashaven-ui/src/app/components/slider/slider.component.html
@@ -1,46 +1,48 @@
 <section class="neo-section neo-slider">
-  <div class="neo-section__header">
-    <span class="neo-section__tag">Featured</span>
-    <h2 class="neo-section__title">Signature Properties</h2>
-    <p class="neo-section__subtitle">
-      A rotating showcase of living spaces shaped by bespoke architecture, thoughtful amenities, and luminous community design.
-    </p>
-  </div>
+  <div class="neo-section__inner">
+    <div class="neo-section__header">
+      <span class="neo-section__tag">Featured</span>
+      <h2 class="neo-section__title">Signature Properties</h2>
+      <p class="neo-section__subtitle">
+        A rotating showcase of living spaces shaped by bespoke architecture, thoughtful amenities, and luminous community design.
+      </p>
+    </div>
 
-  <div class="neo-slider__surface">
-    <swiper-container
-      #swiper
-      init="false"
-      class="neo-slider__container"
-      aria-label="Signature properties slider"
-    >
-      <swiper-slide *ngFor="let slide of slides" class="neo-slider__slide">
-        <article class="neo-slider__card">
-          <div class="neo-slider__media">
-            <img [src]="slide.image" [alt]="slide.name" loading="lazy" />
-            <div class="neo-slider__media-overlay"></div>
-          </div>
-          <div class="neo-slider__content">
-            <span class="neo-slider__badge">{{ slide.category }}</span>
-            <h3>{{ slide.name }}</h3>
-            <p class="neo-slider__address">{{ slide.address }}</p>
-            <p class="neo-slider__description">{{ slide.description }}</p>
-            <a [routerLink]="['/projectdetails', slide.id]" class="neo-slider__cta">
-              Explore Residence
-            </a>
-          </div>
-        </article>
-      </swiper-slide>
-      <div class="swiper-pagination neo-slider__pagination"></div>
-    </swiper-container>
+    <div class="neo-slider__surface">
+      <swiper-container
+        #swiper
+        init="false"
+        class="neo-slider__container"
+        aria-label="Signature properties slider"
+      >
+        <swiper-slide *ngFor="let slide of slides" class="neo-slider__slide">
+          <article class="neo-slider__card">
+            <div class="neo-slider__media">
+              <img [src]="slide.image" [alt]="slide.name" loading="lazy" />
+              <div class="neo-slider__media-overlay"></div>
+            </div>
+            <div class="neo-slider__content">
+              <span class="neo-slider__badge">{{ slide.category }}</span>
+              <h3>{{ slide.name }}</h3>
+              <p class="neo-slider__address">{{ slide.address }}</p>
+              <p class="neo-slider__description">{{ slide.description }}</p>
+              <a [routerLink]="['/projectdetails', slide.id]" class="neo-slider__cta">
+                Explore Residence
+              </a>
+            </div>
+          </article>
+        </swiper-slide>
+        <div class="swiper-pagination neo-slider__pagination"></div>
+      </swiper-container>
 
-    <div class="neo-slider__controls" role="group" aria-label="Slider navigation">
-      <button type="button" aria-label="Previous slide" class="neo-slider__control neo-slider__control--prev">
-        <span>&larr;</span>
-      </button>
-      <button type="button" aria-label="Next slide" class="neo-slider__control neo-slider__control--next">
-        <span>&rarr;</span>
-      </button>
+      <div class="neo-slider__controls" role="group" aria-label="Slider navigation">
+        <button type="button" aria-label="Previous slide" class="neo-slider__control neo-slider__control--prev">
+          <span>&larr;</span>
+        </button>
+        <button type="button" aria-label="Next slide" class="neo-slider__control neo-slider__control--next">
+          <span>&rarr;</span>
+        </button>
+      </div>
     </div>
   </div>
 </section>

--- a/frontend/ashaven-ui/src/app/components/testimonial/testimonial.component.html
+++ b/frontend/ashaven-ui/src/app/components/testimonial/testimonial.component.html
@@ -1,65 +1,67 @@
 <section class="neo-section neo-testimonial" *ngIf="testimonials.length">
-  <div class="neo-section__header">
-    <span class="neo-section__tag">Testimonials</span>
-    <h2 class="neo-section__title">Voices from Our Community</h2>
-    <p class="neo-section__subtitle">
-      Stories from residents, partners, and collaborators experiencing AS Haven’s immersive approach to place-making.
-    </p>
-  </div>
-
-  <div class="neo-testimonial__surface">
-    <button
-      class="neo-testimonial__control neo-testimonial__control--prev"
-      (click)="prev()"
-      aria-label="Previous testimonial"
-      type="button"
-    >
-      <span>&larr;</span>
-    </button>
-
-    <article
-      *ngIf="currentTestimonial"
-      class="neo-testimonial__card"
-      [@slideAnimation]="currentIndex"
-    >
-      <div class="neo-testimonial__profile">
-        <div class="neo-testimonial__avatar">
-          <img
-            *ngIf="currentTestimonial?.image; else placeholderImage"
-            [src]="baseURL + '/api/attachment/get/' + currentTestimonial.image"
-            [alt]="currentTestimonial.name"
-            (error)="onImageError($event)"
-          />
-          <ng-template #placeholderImage>
-            <img
-              src="https://img.freepik.com/free-vector/illustration-gallery-icon_53876-27002.jpg"
-              alt="Placeholder image"
-            />
-          </ng-template>
-        </div>
-        <div class="neo-testimonial__quote" aria-hidden="true">”</div>
-      </div>
-
-      <p class="neo-testimonial__text">
-        {{ currentTestimonial.description }}
+  <div class="neo-section__inner">
+    <div class="neo-section__header">
+      <span class="neo-section__tag">Testimonials</span>
+      <h2 class="neo-section__title">Voices from Our Community</h2>
+      <p class="neo-section__subtitle">
+        Stories from residents, partners, and collaborators experiencing AS Haven’s immersive approach to place-making.
       </p>
+    </div>
 
-      <div class="neo-testimonial__meta">
-        <h3>{{ currentTestimonial.name }}</h3>
-      </div>
-    </article>
+    <div class="neo-testimonial__surface">
+      <button
+        class="neo-testimonial__control neo-testimonial__control--prev"
+        (click)="prev()"
+        aria-label="Previous testimonial"
+        type="button"
+      >
+        <span>&larr;</span>
+      </button>
 
-    <button
-      class="neo-testimonial__control neo-testimonial__control--next"
-      (click)="next()"
-      aria-label="Next testimonial"
-      type="button"
-    >
-      <span>&rarr;</span>
-    </button>
-  </div>
+      <article
+        *ngIf="currentTestimonial"
+        class="neo-testimonial__card"
+        [@slideAnimation]="currentIndex"
+      >
+        <div class="neo-testimonial__profile">
+          <div class="neo-testimonial__avatar">
+            <img
+              *ngIf="currentTestimonial?.image; else placeholderImage"
+              [src]="baseURL + '/api/attachment/get/' + currentTestimonial.image"
+              [alt]="currentTestimonial.name"
+              (error)="onImageError($event)"
+            />
+            <ng-template #placeholderImage>
+              <img
+                src="https://img.freepik.com/free-vector/illustration-gallery-icon_53876-27002.jpg"
+                alt="Placeholder image"
+              />
+            </ng-template>
+          </div>
+          <div class="neo-testimonial__quote" aria-hidden="true">”</div>
+        </div>
 
-  <div class="neo-testimonial__pagination">
-    {{ currentIndex + 1 }} / {{ testimonials.length }}
+        <p class="neo-testimonial__text">
+          {{ currentTestimonial.description }}
+        </p>
+
+        <div class="neo-testimonial__meta">
+          <h3>{{ currentTestimonial.name }}</h3>
+        </div>
+      </article>
+
+      <button
+        class="neo-testimonial__control neo-testimonial__control--next"
+        (click)="next()"
+        aria-label="Next testimonial"
+        type="button"
+      >
+        <span>&rarr;</span>
+      </button>
+    </div>
+
+    <div class="neo-testimonial__pagination">
+      {{ currentIndex + 1 }} / {{ testimonials.length }}
+    </div>
   </div>
 </section>

--- a/frontend/ashaven-ui/src/app/components/vision-banner/vision-banner.component.css
+++ b/frontend/ashaven-ui/src/app/components/vision-banner/vision-banner.component.css
@@ -7,7 +7,8 @@
   overflow: hidden;
   border-radius: var(--neo-radius-lg);
   min-height: clamp(420px, 65vh, 560px);
-  margin-inline: clamp(1rem, 5vw, 3rem);
+  width: min(92vw, 1200px);
+  margin: 0 auto;
   box-shadow: 0 45px 110px rgba(19, 53, 31, 0.28);
 }
 
@@ -102,8 +103,8 @@
   box-shadow: 0 35px 75px rgba(255, 119, 27, 0.38);
 }
 
-@media (max-width: 767px) {
+@media (min-width: 1024px) {
   .neo-vision {
-    margin-inline: clamp(0.5rem, 4vw, 1.2rem);
+    width: min(85vw, 1200px);
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/about/hero-section/hero-section.component.html
+++ b/frontend/ashaven-ui/src/app/pages/about/hero-section/hero-section.component.html
@@ -11,7 +11,7 @@
   <div class="hero__accent hero__accent--two"></div>
 
   <div class="relative z-10 flex h-full w-full items-center">
-    <div class="mx-auto flex h-full w-[90%] max-w-6xl flex-col justify-center py-16 md:py-24">
+    <div class="page-width flex h-full flex-col justify-center py-16 md:py-24">
       <div class="grid items-center gap-12 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
         <div class="space-y-6 text-center lg:text-left">
           <span class="inline-flex items-center justify-center gap-2 text-[0.7rem] uppercase tracking-[0.6em] text-white/70 lg:justify-start">

--- a/frontend/ashaven-ui/src/app/pages/about/history/history.component.html
+++ b/frontend/ashaven-ui/src/app/pages/about/history/history.component.html
@@ -2,7 +2,7 @@
   <div class="history-section__glow history-section__glow--one"></div>
   <div class="history-section__glow history-section__glow--two"></div>
 
-  <div class="mx-auto flex w-[90%] max-w-6xl flex-col gap-12 lg:flex-row lg:items-start">
+  <div class="page-width flex flex-col gap-12 lg:flex-row lg:items-start">
     <div class="space-y-6 lg:w-7/12">
       <span class="inline-flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.6em] text-accent">
         <span class="h-2 w-2 rounded-full bg-accent"></span>

--- a/frontend/ashaven-ui/src/app/pages/about/mission-vision/mission-vision.component.html
+++ b/frontend/ashaven-ui/src/app/pages/about/mission-vision/mission-vision.component.html
@@ -2,7 +2,7 @@
   <div class="mission-vision__glow mission-vision__glow--one"></div>
   <div class="mission-vision__glow mission-vision__glow--two"></div>
 
-  <div class="w-[90%] max-w-6xl mx-auto space-y-16">
+  <div class="page-width space-y-16">
     <div class="flex flex-col items-center gap-10 lg:flex-row">
       <div class="order-2 w-full space-y-6 rounded-[2.5rem] bg-white/90 p-10 shadow-2xl backdrop-blur md:order-1 md:w-1/2">
         <span class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.6em] text-accent">

--- a/frontend/ashaven-ui/src/app/pages/about/owner-speech/owner-speech.component.html
+++ b/frontend/ashaven-ui/src/app/pages/about/owner-speech/owner-speech.component.html
@@ -2,7 +2,7 @@
   <div class="owner-speech__glow owner-speech__glow--one"></div>
   <div class="owner-speech__glow owner-speech__glow--two"></div>
 
-  <div class="w-[90%] max-w-6xl mx-auto rounded-[3rem] border border-dark/5 bg-white/95 px-8 py-12 shadow-2xl backdrop-blur">
+  <div class="page-width rounded-[3rem] border border-dark/5 bg-white/95 px-8 py-12 shadow-2xl backdrop-blur">
     <div class="flex flex-col gap-12 lg:flex-row lg:items-start">
       <div class="flex w-full flex-shrink-0 justify-center lg:w-1/3">
         <div class="owner-speech__portrait">

--- a/frontend/ashaven-ui/src/app/pages/about/team/team.component.html
+++ b/frontend/ashaven-ui/src/app/pages/about/team/team.component.html
@@ -1,5 +1,5 @@
 <div class="our_team py-20 px-6 fade-up">
-  <div class="max-w-7xl mx-auto">
+  <div class="page-width">
     <h2
       class="text-4xl md:text-5xl font-bold text-[var(--dark)] mb-16 text-center"
     >

--- a/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.html
@@ -11,7 +11,7 @@
     <div class="hero-orb hero-orb--two"></div>
   </div>
 
-  <div class="relative z-10 max-w-6xl mx-auto px-6 py-24 md:py-32">
+  <div class="page-width relative z-10 px-6 py-24 md:py-32">
     <div class="flex flex-col md:flex-row gap-14 md:gap-20 items-start">
       <div class="md:w-3/5 space-y-8 fade-up">
         <span class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs md:text-sm uppercase tracking-[0.25em] bg-white/10 border border-white/20">

--- a/frontend/ashaven-ui/src/app/pages/contact/contact-info-map/contact-info-map.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/contact-info-map/contact-info-map.component.html
@@ -4,7 +4,7 @@
   <div class="connect-aurora connect-aurora--sky"></div>
   <div class="connect-grid"></div>
 
-  <div class="relative max-w-6xl mx-auto px-6 py-24">
+  <div class="page-width relative px-6 py-24">
     <div class="flex flex-col lg:flex-row items-start gap-12 lg:gap-16 fade-up">
       <div class="space-y-6 lg:w-2/5">
         <span class="connect-pill">Tell us about your vision</span>

--- a/frontend/ashaven-ui/src/app/pages/contact/faq/faq.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/faq/faq.component.html
@@ -4,7 +4,7 @@
   <div class="faq-aurora faq-aurora--violet"></div>
   <div class="faq-grid"></div>
 
-  <div class="relative max-w-5xl mx-auto px-6 py-20 md:py-24">
+  <div class="page-width relative px-6 py-20 md:py-24">
     <div class="text-center fade-up space-y-4">
       <span class="faq-pill">Frequently asked</span>
       <h2 class="text-3xl md:text-4xl font-semibold text-[var(--luxe-forest-900)]">

--- a/frontend/ashaven-ui/src/app/pages/contact/get-in-touch/get-in-touch.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/get-in-touch/get-in-touch.component.html
@@ -4,7 +4,7 @@
   <div class="touch-aurora touch-aurora--two"></div>
   <div class="touch-noise"></div>
 
-  <div class="relative max-w-6xl mx-auto px-6 py-20 md:py-24">
+  <div class="page-width relative px-6 py-20 md:py-24">
     <div class="text-center fade-up space-y-4 max-w-3xl mx-auto">
       <span class="section-pill">Ways to reach us</span>
       <h2 class="text-3xl sm:text-4xl lg:text-5xl font-semibold text-[var(--luxe-forest-900)]">

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
@@ -13,9 +13,9 @@
   <div class="gallery-hero__accent gallery-hero__accent--one"></div>
   <div class="gallery-hero__accent gallery-hero__accent--two"></div>
 
-  <div class="relative z-10 flex h-full w-full items-center">
-    <div class="mx-auto flex h-full w-[90%] max-w-6xl flex-col justify-center py-16 md:py-24">
-      <div class="grid items-center gap-12 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+    <div class="relative z-10 flex h-full w-full items-center">
+      <div class="page-width flex h-full flex-col justify-center py-16 md:py-24">
+        <div class="grid items-center gap-12 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
         <div class="space-y-6 text-center lg:text-left">
           <span class="inline-flex items-center justify-center gap-2 text-[0.7rem] uppercase tracking-[0.6em] text-white/70 lg:justify-start">
             <span class="h-2 w-2 rounded-full bg-accent"></span>

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.css
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-page.component.css
@@ -36,11 +36,17 @@
 .gallery-shell {
   position: relative;
   z-index: 1;
-  width: min(1100px, 92vw);
+  width: min(92vw, 1200px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+@media (min-width: 1024px) {
+  .gallery-shell {
+    width: min(85vw, 1200px);
+  }
 }
 
 .gallery-intro {

--- a/frontend/ashaven-ui/src/app/pages/project/project.component.html
+++ b/frontend/ashaven-ui/src/app/pages/project/project.component.html
@@ -9,7 +9,7 @@
 
     <div class="hero-overlay absolute inset-0"></div>
 
-    <div class="hero-content relative z-10 w-[90%] sm:w-[85%] lg:w-[70%] mx-auto">
+    <div class="hero-content page-width relative z-10">
       <span class="inline-flex items-center justify-center gap-2 text-[0.7rem] uppercase tracking-[0.6em] text-white/70 lg:justify-start">
             <span class="h-2 w-2 rounded-full bg-accent"></span>
             Signature Collection
@@ -48,7 +48,7 @@
 
   <!-- Filter Bar -->
   <section id="project-filters" class="filter-section">
-    <div class="container w-[90%] md:w-[85%] mx-auto">
+    <div class="page-width">
       <div class="filter-card">
         <div class="filter-card__header">
           <div>
@@ -122,7 +122,7 @@
 
   <!-- Projects Grid -->
   <section class="projects-section">
-    <div class="container w-[90%] md:w-[85%] mx-auto">
+    <div class="page-width">
       <header class="projects-header">
         <div>
           <h2>Featured developments</h2>

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -116,19 +116,25 @@ img {
 
 .neo-section {
   position: relative;
-  padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 4vw, 3.75rem);
+  padding-block: clamp(4rem, 8vw, 6.5rem);
   width: 100%;
-  max-width: min(92vw, 1200px);
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2rem, 5vw, 3.5rem);
   z-index: 1;
 }
 
+.neo-section__inner {
+  width: 100%;
+  max-width: min(92vw, 1200px);
+  margin-inline: auto;
+  padding-inline: clamp(1.5rem, 5vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3.5rem);
+}
+
 @media (min-width: 1024px) {
-  .neo-section {
+  .neo-section__inner {
     max-width: min(85vw, 1680px);
+    padding-inline: 0;
   }
 }
 
@@ -137,13 +143,20 @@ img {
   position: absolute;
   inset: 0;
   margin: auto;
-  max-width: 98%;
+  width: 100%;
+  max-width: min(92vw, 1200px);
   border-radius: calc(var(--neo-radius-lg) * 1.15);
   background: radial-gradient(circle at top, rgba(255, 119, 27, 0.08), transparent 70%),
     radial-gradient(circle at bottom left, rgba(32, 71, 38, 0.12), transparent 65%);
   filter: blur(80px);
   opacity: 0.6;
   z-index: -1;
+}
+
+@media (min-width: 1024px) {
+  .neo-section::after {
+    max-width: min(85vw, 1680px);
+  }
 }
 
 .neo-section__header {

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -40,6 +40,17 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+.page-width {
+  width: min(92vw, 1200px);
+  margin-inline: auto;
+}
+
+@media (min-width: 1024px) {
+  .page-width {
+    width: min(85vw, 1200px);
+  }
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -104,12 +115,18 @@ img {
 .neo-section {
   position: relative;
   padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 6vw, 4.5rem);
-  width: min(1140px, 100%);
+  width: min(92vw, 1200px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: clamp(2rem, 5vw, 3.5rem);
   z-index: 1;
+}
+
+@media (min-width: 1024px) {
+  .neo-section {
+    width: min(85vw, 1200px);
+  }
 }
 
 .neo-section::after {

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -48,7 +48,7 @@
 
 @media (min-width: 1024px) {
   .page-width {
-    max-width: min(85vw, 1200px);
+    max-width: min(85vw, 1680px);
   }
 }
 
@@ -128,7 +128,7 @@ img {
 
 @media (min-width: 1024px) {
   .neo-section {
-    max-width: min(85vw, 1200px);
+    max-width: min(85vw, 1680px);
   }
 }
 

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -112,9 +112,10 @@ img {
   backdrop-filter: blur(24px);
 }
 
+
 .neo-section {
   position: relative;
-  padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 6vw, 4.5rem);
+  padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 4vw, 3.75rem);
   width: min(92vw, 1200px);
   margin: 0 auto;
   display: flex;

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -41,13 +41,14 @@
 }
 
 .page-width {
-  width: min(92vw, 1200px);
+  width: 100%;
+  max-width: min(92vw, 1200px);
   margin-inline: auto;
 }
 
 @media (min-width: 1024px) {
   .page-width {
-    width: min(85vw, 1200px);
+    max-width: min(85vw, 1200px);
   }
 }
 
@@ -116,7 +117,8 @@ img {
 .neo-section {
   position: relative;
   padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 4vw, 3.75rem);
-  width: min(92vw, 1200px);
+  width: 100%;
+  max-width: min(92vw, 1200px);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -126,7 +128,7 @@ img {
 
 @media (min-width: 1024px) {
   .neo-section {
-    width: min(85vw, 1200px);
+    max-width: min(85vw, 1200px);
   }
 }
 

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -40,18 +40,6 @@
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-.page-width {
-  width: 100%;
-  max-width: min(92vw, 1200px);
-  margin-inline: auto;
-}
-
-@media (min-width: 1024px) {
-  .page-width {
-    max-width: min(85vw, 1680px);
-  }
-}
-
 * {
   margin: 0;
   padding: 0;
@@ -114,88 +102,64 @@ img {
 }
 
 
-.neo-section {
-  position: relative;
-  padding-block: clamp(4rem, 8vw, 6.5rem);
-  width: 100%;
-  z-index: 1;
-}
+@layer components {
+  .page-width {
+    @apply mx-auto w-full max-w-content lg:max-w-content-lg;
+  }
 
-.neo-section__inner {
-  width: 100%;
-  max-width: min(92vw, 1200px);
-  margin-inline: auto;
-  padding-inline: clamp(1.5rem, 5vw, 2rem);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(2rem, 5vw, 3.5rem);
-}
+  .neo-section {
+    --neo-section-max: min(92vw, 1200px);
+    @apply relative z-[1] w-full py-section-y;
+  }
 
-@media (min-width: 1024px) {
+  @screen lg {
+    .neo-section {
+      --neo-section-max: min(85vw, 1680px);
+    }
+  }
+
   .neo-section__inner {
-    max-width: min(85vw, 1680px);
-    padding-inline: 0;
+    @apply relative z-[1] mx-auto flex w-full max-w-content flex-col gap-section-gap px-section-x lg:max-w-content-lg lg:px-0;
   }
-}
 
-.neo-section::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  width: 100%;
-  max-width: min(92vw, 1200px);
-  border-radius: calc(var(--neo-radius-lg) * 1.15);
-  background: radial-gradient(circle at top, rgba(255, 119, 27, 0.08), transparent 70%),
-    radial-gradient(circle at bottom left, rgba(32, 71, 38, 0.12), transparent 65%);
-  filter: blur(80px);
-  opacity: 0.6;
-  z-index: -1;
-}
-
-@media (min-width: 1024px) {
   .neo-section::after {
-    max-width: min(85vw, 1680px);
+    content: '';
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 100%;
+    max-width: var(--neo-section-max);
+    border-radius: calc(var(--neo-radius-lg) * 1.15);
+    background: radial-gradient(circle at top, rgba(255, 119, 27, 0.08), transparent 70%),
+      radial-gradient(circle at bottom left, rgba(32, 71, 38, 0.12), transparent 65%);
+    filter: blur(80px);
+    opacity: 0.6;
+    z-index: -1;
   }
-}
 
-.neo-section__header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  align-items: flex-start;
-  max-width: 720px;
-}
+  .neo-section__header {
+    @apply flex max-w-[720px] flex-col items-start gap-3;
+  }
 
-.neo-section__tag {
-  font-size: 0.78rem;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
-  color: rgba(32, 71, 38, 0.65);
-}
+  .neo-section__tag {
+    @apply text-[0.78rem] uppercase tracking-[0.28em] text-[rgba(32,71,38,0.65)];
+  }
 
-.neo-section__title {
-  font-size: clamp(2.4rem, 4vw, 3.5rem);
-  font-family: 'Playfair Display', serif;
-  font-weight: 600;
-  color: var(--luxe-forest-900);
-  line-height: 1.05;
-}
+  .neo-section__title {
+    @apply font-serif text-[clamp(2.4rem,4vw,3.5rem)] font-semibold leading-[1.05] text-[#132b18];
+  }
 
-.neo-section__subtitle {
-  max-width: 56ch;
-  line-height: 1.7;
-  color: rgba(0, 0, 0, 0.68);
-  font-size: clamp(1rem, 1.8vw, 1.18rem);
-}
+  .neo-section__subtitle {
+    @apply max-w-[56ch] text-[clamp(1rem,1.8vw,1.18rem)] leading-[1.7] text-[rgba(0,0,0,0.68)];
+  }
 
-.neo-grid {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-}
+  .neo-grid {
+    @apply grid gap-[clamp(1.5rem,4vw,2.5rem)];
+  }
 
-.neo-grid--quarters {
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  .neo-grid--quarters {
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  }
 }
 
 .neo-card {

--- a/frontend/ashaven-ui/tailwind.config.js
+++ b/frontend/ashaven-ui/tailwind.config.js
@@ -14,6 +14,15 @@ module.exports = {
         sans: ["Inter", "system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "sans-serif"],
         serif: ["Playfair Display", "serif"],
       },
+      maxWidth: {
+        content: "min(92vw, 1200px)",
+        "content-lg": "min(85vw, 1680px)",
+      },
+      spacing: {
+        "section-y": "clamp(4rem, 8vw, 6.5rem)",
+        "section-x": "clamp(1.5rem, 5vw, 2rem)",
+        "section-gap": "clamp(2rem, 5vw, 3.5rem)",
+      },
       boxShadow: {
         "luxe-glow": "0 30px 80px rgba(32, 71, 38, 0.25)",
         "luxe-soft": "0 18px 50px rgba(32, 71, 38, 0.18)",


### PR DESCRIPTION
## Summary
- add a reusable `.page-width` utility and update shared sections so desktop layouts center within roughly 85% of the viewport
- refit home, about, project, gallery, and contact hero/section containers to use the shared width treatment for consistent alignment

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e4875cf6d08323b1d5041f89b3ff12