### PR TITLE
Align home page layout with about page spacing

### DIFF
--- a/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
+++ b/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
@@ -20,6 +20,9 @@
   overflow: hidden;
   color: var(--neo-text);
   box-shadow: 0 40px 120px rgba(16, 38, 24, 0.55);
+  width: min(90%, 72rem);
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .neo-hero__background {

--- a/frontend/ashaven-ui/src/app/components/vision-banner/vision-banner.component.css
+++ b/frontend/ashaven-ui/src/app/components/vision-banner/vision-banner.component.css
@@ -7,8 +7,10 @@
   overflow: hidden;
   border-radius: var(--neo-radius-lg);
   min-height: clamp(420px, 65vh, 560px);
-  margin-inline: clamp(1rem, 5vw, 3rem);
   box-shadow: 0 45px 110px rgba(19, 53, 31, 0.28);
+  width: min(90%, 72rem);
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .neo-vision__background {
@@ -104,6 +106,6 @@
 
 @media (max-width: 767px) {
   .neo-vision {
-    margin-inline: clamp(0.5rem, 4vw, 1.2rem);
+    width: 90%;
   }
 }

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -104,12 +104,13 @@ img {
 .neo-section {
   position: relative;
   padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 6vw, 4.5rem);
-  width: min(1140px, 100%);
+  width: min(90%, 72rem);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: clamp(2rem, 5vw, 3.5rem);
   z-index: 1;
+  box-sizing: border-box;
 }
 
 .neo-section::after {


### PR DESCRIPTION
## Summary
- update the shared neo-section layout to use a 90% width cap that matches the about page container
- center the hero slide and vision banner components with the same max-width treatment for consistent left/right alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4f89817fc8323848862be4ddedfb4