### PR TITLE
Make home page components span full width

### DIFF
--- a/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
+++ b/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.css
@@ -12,14 +12,16 @@
   position: relative;
   isolation: isolate;
   min-height: clamp(620px, 88vh, 900px);
-  padding: clamp(2.5rem, 4vw, 4.5rem);
-  border-radius: clamp(2rem, 5vw, 3.5rem);
+  padding: clamp(2.5rem, 4vw, 4.5rem) 0;
+  border-radius: 0;
   background: radial-gradient(circle at 12% 16%, rgba(255, 255, 255, 0.08), transparent 60%),
     radial-gradient(circle at 90% 0%, rgba(255, 119, 27, 0.22), transparent 70%),
     linear-gradient(140deg, rgba(20, 44, 27, 0.94), rgba(10, 24, 15, 0.9));
   overflow: hidden;
   color: var(--neo-text);
   box-shadow: 0 40px 120px rgba(16, 38, 24, 0.55);
+  width: 100%;
+  margin: 0;
 }
 
 .neo-hero__background {
@@ -78,11 +80,12 @@
 .neo-hero__container {
   position: relative;
   z-index: 2;
-  max-width: 1200px;
+  width: min(90%, 72rem);
   margin: 0 auto;
   height: 100%;
   display: flex;
   align-items: center;
+  box-sizing: border-box;
 }
 
 .neo-hero__grid {
@@ -419,7 +422,8 @@
 
 @media (max-width: 900px) {
   .neo-hero {
-    border-radius: 2.5rem;
+    border-radius: 0;
+    padding: clamp(2.5rem, 6vw, 3.5rem) 0;
   }
 
   .neo-hero__grid {
@@ -448,8 +452,8 @@
 
 @media (max-width: 600px) {
   .neo-hero {
-    padding: 2.5rem 1.5rem;
-    border-radius: 1.8rem;
+    padding: 2.5rem 0;
+    border-radius: 0;
   }
 
   .neo-hero__meta {

--- a/frontend/ashaven-ui/src/app/components/project-explore/project-explore.component.html
+++ b/frontend/ashaven-ui/src/app/components/project-explore/project-explore.component.html
@@ -1,33 +1,35 @@
-<section class="neo-section" id="projects">
-  <div class="neo-section__header">
-    <span class="neo-section__tag">Curated Collection</span>
-    <h2 class="neo-section__title">Explore Our Signature Projects</h2>
-    <p class="neo-section__subtitle">
-      Discover the communities, residences, and visionary spaces defining AS Haven’s next chapter.
-    </p>
-  </div>
+<section class="neo-section neo-section--wide" id="projects">
+  <div class="neo-section__inner">
+    <div class="neo-section__header">
+      <span class="neo-section__tag">Curated Collection</span>
+      <h2 class="neo-section__title">Explore Our Signature Projects</h2>
+      <p class="neo-section__subtitle">
+        Discover the communities, residences, and visionary spaces defining AS Haven’s next chapter.
+      </p>
+    </div>
 
-  <div class="neo-projects-grid">
-    <article
-      *ngFor="let item of projects"
-      class="neo-project-card"
-      (mousemove)="onMouseMove($event)"
-      (mouseleave)="onMouseLeave($event)"
-    >
-      <a
-        [routerLink]="item.route"
-        [queryParams]="{ category: item.title.split(' ')[0] }"
-        class="neo-project-card__inner"
+    <div class="neo-projects-grid">
+      <article
+        *ngFor="let item of projects"
+        class="neo-project-card"
+        (mousemove)="onMouseMove($event)"
+        (mouseleave)="onMouseLeave($event)"
       >
-        <div class="neo-project-card__halo" aria-hidden="true"></div>
-        <div class="neo-project-card__media">
-          <img [src]="item.image" [alt]="item.title + ' icon'" />
-        </div>
-        <div class="neo-project-card__content">
-          <h3>{{ item.title }}</h3>
-          <p>Explore ↗</p>
-        </div>
-      </a>
-    </article>
+        <a
+          [routerLink]="item.route"
+          [queryParams]="{ category: item.title.split(' ')[0] }"
+          class="neo-project-card__inner"
+        >
+          <div class="neo-project-card__halo" aria-hidden="true"></div>
+          <div class="neo-project-card__media">
+            <img [src]="item.image" [alt]="item.title + ' icon'" />
+          </div>
+          <div class="neo-project-card__content">
+            <h3>{{ item.title }}</h3>
+            <p>Explore ↗</p>
+          </div>
+        </a>
+      </article>
+    </div>
   </div>
 </section>

--- a/frontend/ashaven-ui/src/app/components/slider/slider.component.html
+++ b/frontend/ashaven-ui/src/app/components/slider/slider.component.html
@@ -1,46 +1,48 @@
-<section class="neo-section neo-slider">
-  <div class="neo-section__header">
-    <span class="neo-section__tag">Featured</span>
-    <h2 class="neo-section__title">Signature Properties</h2>
-    <p class="neo-section__subtitle">
-      A rotating showcase of living spaces shaped by bespoke architecture, thoughtful amenities, and luminous community design.
-    </p>
-  </div>
+<section class="neo-section neo-section--wide neo-slider">
+  <div class="neo-section__inner">
+    <div class="neo-section__header">
+      <span class="neo-section__tag">Featured</span>
+      <h2 class="neo-section__title">Signature Properties</h2>
+      <p class="neo-section__subtitle">
+        A rotating showcase of living spaces shaped by bespoke architecture, thoughtful amenities, and luminous community design.
+      </p>
+    </div>
 
-  <div class="neo-slider__surface">
-    <swiper-container
-      #swiper
-      init="false"
-      class="neo-slider__container"
-      aria-label="Signature properties slider"
-    >
-      <swiper-slide *ngFor="let slide of slides" class="neo-slider__slide">
-        <article class="neo-slider__card">
-          <div class="neo-slider__media">
-            <img [src]="slide.image" [alt]="slide.name" loading="lazy" />
-            <div class="neo-slider__media-overlay"></div>
-          </div>
-          <div class="neo-slider__content">
-            <span class="neo-slider__badge">{{ slide.category }}</span>
-            <h3>{{ slide.name }}</h3>
-            <p class="neo-slider__address">{{ slide.address }}</p>
-            <p class="neo-slider__description">{{ slide.description }}</p>
-            <a [routerLink]="['/projectdetails', slide.id]" class="neo-slider__cta">
-              Explore Residence
-            </a>
-          </div>
-        </article>
-      </swiper-slide>
-      <div class="swiper-pagination neo-slider__pagination"></div>
-    </swiper-container>
+    <div class="neo-slider__surface">
+      <swiper-container
+        #swiper
+        init="false"
+        class="neo-slider__container"
+        aria-label="Signature properties slider"
+      >
+        <swiper-slide *ngFor="let slide of slides" class="neo-slider__slide">
+          <article class="neo-slider__card">
+            <div class="neo-slider__media">
+              <img [src]="slide.image" [alt]="slide.name" loading="lazy" />
+              <div class="neo-slider__media-overlay"></div>
+            </div>
+            <div class="neo-slider__content">
+              <span class="neo-slider__badge">{{ slide.category }}</span>
+              <h3>{{ slide.name }}</h3>
+              <p class="neo-slider__address">{{ slide.address }}</p>
+              <p class="neo-slider__description">{{ slide.description }}</p>
+              <a [routerLink]="['/projectdetails', slide.id]" class="neo-slider__cta">
+                Explore Residence
+              </a>
+            </div>
+          </article>
+        </swiper-slide>
+        <div class="swiper-pagination neo-slider__pagination"></div>
+      </swiper-container>
 
-    <div class="neo-slider__controls" role="group" aria-label="Slider navigation">
-      <button type="button" aria-label="Previous slide" class="neo-slider__control neo-slider__control--prev">
-        <span>&larr;</span>
-      </button>
-      <button type="button" aria-label="Next slide" class="neo-slider__control neo-slider__control--next">
-        <span>&rarr;</span>
-      </button>
+      <div class="neo-slider__controls" role="group" aria-label="Slider navigation">
+        <button type="button" aria-label="Previous slide" class="neo-slider__control neo-slider__control--prev">
+          <span>&larr;</span>
+        </button>
+        <button type="button" aria-label="Next slide" class="neo-slider__control neo-slider__control--next">
+          <span>&rarr;</span>
+        </button>
+      </div>
     </div>
   </div>
 </section>

--- a/frontend/ashaven-ui/src/app/components/testimonial/testimonial.component.html
+++ b/frontend/ashaven-ui/src/app/components/testimonial/testimonial.component.html
@@ -1,65 +1,67 @@
-<section class="neo-section neo-testimonial" *ngIf="testimonials.length">
-  <div class="neo-section__header">
-    <span class="neo-section__tag">Testimonials</span>
-    <h2 class="neo-section__title">Voices from Our Community</h2>
-    <p class="neo-section__subtitle">
-      Stories from residents, partners, and collaborators experiencing AS Haven’s immersive approach to place-making.
-    </p>
-  </div>
-
-  <div class="neo-testimonial__surface">
-    <button
-      class="neo-testimonial__control neo-testimonial__control--prev"
-      (click)="prev()"
-      aria-label="Previous testimonial"
-      type="button"
-    >
-      <span>&larr;</span>
-    </button>
-
-    <article
-      *ngIf="currentTestimonial"
-      class="neo-testimonial__card"
-      [@slideAnimation]="currentIndex"
-    >
-      <div class="neo-testimonial__profile">
-        <div class="neo-testimonial__avatar">
-          <img
-            *ngIf="currentTestimonial?.image; else placeholderImage"
-            [src]="baseURL + '/api/attachment/get/' + currentTestimonial.image"
-            [alt]="currentTestimonial.name"
-            (error)="onImageError($event)"
-          />
-          <ng-template #placeholderImage>
-            <img
-              src="https://img.freepik.com/free-vector/illustration-gallery-icon_53876-27002.jpg"
-              alt="Placeholder image"
-            />
-          </ng-template>
-        </div>
-        <div class="neo-testimonial__quote" aria-hidden="true">”</div>
-      </div>
-
-      <p class="neo-testimonial__text">
-        {{ currentTestimonial.description }}
+<section class="neo-section neo-section--wide neo-testimonial" *ngIf="testimonials.length">
+  <div class="neo-section__inner">
+    <div class="neo-section__header">
+      <span class="neo-section__tag">Testimonials</span>
+      <h2 class="neo-section__title">Voices from Our Community</h2>
+      <p class="neo-section__subtitle">
+        Stories from residents, partners, and collaborators experiencing AS Haven’s immersive approach to place-making.
       </p>
+    </div>
 
-      <div class="neo-testimonial__meta">
-        <h3>{{ currentTestimonial.name }}</h3>
-      </div>
-    </article>
+    <div class="neo-testimonial__surface">
+      <button
+        class="neo-testimonial__control neo-testimonial__control--prev"
+        (click)="prev()"
+        aria-label="Previous testimonial"
+        type="button"
+      >
+        <span>&larr;</span>
+      </button>
 
-    <button
-      class="neo-testimonial__control neo-testimonial__control--next"
-      (click)="next()"
-      aria-label="Next testimonial"
-      type="button"
-    >
-      <span>&rarr;</span>
-    </button>
-  </div>
+      <article
+        *ngIf="currentTestimonial"
+        class="neo-testimonial__card"
+        [@slideAnimation]="currentIndex"
+      >
+        <div class="neo-testimonial__profile">
+          <div class="neo-testimonial__avatar">
+            <img
+              *ngIf="currentTestimonial?.image; else placeholderImage"
+              [src]="baseURL + '/api/attachment/get/' + currentTestimonial.image"
+              [alt]="currentTestimonial.name"
+              (error)="onImageError($event)"
+            />
+            <ng-template #placeholderImage>
+              <img
+                src="https://img.freepik.com/free-vector/illustration-gallery-icon_53876-27002.jpg"
+                alt="Placeholder image"
+              />
+            </ng-template>
+          </div>
+          <div class="neo-testimonial__quote" aria-hidden="true">”</div>
+        </div>
 
-  <div class="neo-testimonial__pagination">
-    {{ currentIndex + 1 }} / {{ testimonials.length }}
+        <p class="neo-testimonial__text">
+          {{ currentTestimonial.description }}
+        </p>
+
+        <div class="neo-testimonial__meta">
+          <h3>{{ currentTestimonial.name }}</h3>
+        </div>
+      </article>
+
+      <button
+        class="neo-testimonial__control neo-testimonial__control--next"
+        (click)="next()"
+        aria-label="Next testimonial"
+        type="button"
+      >
+        <span>&rarr;</span>
+      </button>
+    </div>
+
+    <div class="neo-testimonial__pagination">
+      {{ currentIndex + 1 }} / {{ testimonials.length }}
+    </div>
   </div>
 </section>

--- a/frontend/ashaven-ui/src/app/components/vision-banner/vision-banner.component.css
+++ b/frontend/ashaven-ui/src/app/components/vision-banner/vision-banner.component.css
@@ -5,10 +5,12 @@
 .neo-vision {
   position: relative;
   overflow: hidden;
-  border-radius: var(--neo-radius-lg);
+  border-radius: 0;
   min-height: clamp(420px, 65vh, 560px);
-  margin-inline: clamp(1rem, 5vw, 3rem);
   box-shadow: 0 45px 110px rgba(19, 53, 31, 0.28);
+  width: 100%;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 .neo-vision__background {
@@ -58,8 +60,9 @@
   padding: clamp(3rem, 8vw, 5rem) clamp(2rem, 6vw, 4.5rem);
   display: grid;
   gap: clamp(1rem, 3vw, 1.5rem);
-  max-width: min(600px, 90%);
   color: var(--neo-text);
+  width: min(90%, 72rem);
+  margin: 0 auto;
 }
 
 .neo-vision__title {
@@ -75,10 +78,12 @@
   margin-left: clamp(0rem, 4vw, 1.5rem);
 }
 
+
 .neo-vision__description {
   font-size: clamp(1rem, 1.9vw, 1.2rem);
   line-height: 1.8;
   color: rgba(241, 251, 236, 0.75);
+  max-width: 60ch;
 }
 
 .neo-vision__cta {
@@ -102,8 +107,3 @@
   box-shadow: 0 35px 75px rgba(255, 119, 27, 0.38);
 }
 
-@media (max-width: 767px) {
-  .neo-vision {
-    margin-inline: clamp(0.5rem, 4vw, 1.2rem);
-  }
-}

--- a/frontend/ashaven-ui/src/styles.css
+++ b/frontend/ashaven-ui/src/styles.css
@@ -104,12 +104,34 @@ img {
 .neo-section {
   position: relative;
   padding: clamp(4rem, 8vw, 6.5rem) clamp(1.5rem, 6vw, 4.5rem);
-  width: min(1140px, 100%);
+  width: min(90%, 72rem);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: clamp(2rem, 5vw, 3.5rem);
   z-index: 1;
+  box-sizing: border-box;
+}
+
+.neo-section--wide {
+  width: 100%;
+  margin: 0;
+  padding: clamp(4rem, 8vw, 6.5rem) 0;
+  display: block;
+}
+
+.neo-section--wide .neo-section__inner {
+  width: min(90%, 72rem);
+}
+
+.neo-section__inner {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 0 clamp(1.5rem, 6vw, 4.5rem);
+  width: 100%;
 }
 
 .neo-section::after {
@@ -124,6 +146,10 @@ img {
   filter: blur(80px);
   opacity: 0.6;
   z-index: -1;
+}
+
+.neo-section--wide::after {
+  max-width: min(98%, 72rem);
 }
 
 .neo-section__header {


### PR DESCRIPTION
## Summary
- wrap home page sections with a new `neo-section--wide` container so their backgrounds reach the viewport edges while content stays aligned with the site grid
- stretch the vision banner to the full screen width and constrain its text column for consistent readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f89817fc8323848862be4ddedfb4