### PR TITLE
Align homepage content spacing with about page layout

### DIFF
--- a/frontend/ashaven-ui/src/app/pages/home/home.component.css
+++ b/frontend/ashaven-ui/src/app/pages/home/home.component.css
@@ -1,0 +1,45 @@
+:host {
+  display: block;
+}
+
+.home-layout {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 6vw, 4.5rem);
+  padding-block: clamp(2.5rem, 7vw, 5rem);
+}
+
+.home-section {
+  display: block;
+  width: min(90%, 72rem);
+  margin: 0 auto;
+}
+
+.home-section--hero {
+  width: min(92%, 80rem);
+}
+
+.home-section--vision {
+  width: min(92%, 76rem);
+}
+
+@media (max-width: 1024px) {
+  .home-section,
+  .home-section--hero,
+  .home-section--vision {
+    width: min(94%, 60rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .home-layout {
+    gap: clamp(2.5rem, 10vw, 3rem);
+    padding-block: clamp(2rem, 12vw, 3.5rem);
+  }
+
+  .home-section,
+  .home-section--hero,
+  .home-section--vision {
+    width: 92%;
+  }
+}

--- a/frontend/ashaven-ui/src/app/pages/home/home.component.html
+++ b/frontend/ashaven-ui/src/app/pages/home/home.component.html
@@ -1,5 +1,7 @@
-<app-hero-slide />
-<app-project-explore />
-<app-slider />
-<app-vision-banner />
-<app-testimonial />
+<div class="home-layout">
+  <app-hero-slide class="home-section home-section--hero"></app-hero-slide>
+  <app-project-explore class="home-section"></app-project-explore>
+  <app-slider class="home-section"></app-slider>
+  <app-vision-banner class="home-section home-section--vision"></app-vision-banner>
+  <app-testimonial class="home-section"></app-testimonial>
+</div>


### PR DESCRIPTION
## Summary
- wrap the home page sections in a shared layout container so they inherit consistent horizontal spacing
- add responsive CSS helpers that center each section and match the about page width constraints

## Testing
- `npm run build` *(fails: external Google Fonts stylesheet cannot be inlined and returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e50c7869908323b2940f55bec9bff3