### PR TITLE
Reduce scroll listener load to improve scroll performance

### DIFF
--- a/frontend/ashaven-ui/src/app/directives/navbar-scroll.directive.ts
+++ b/frontend/ashaven-ui/src/app/directives/navbar-scroll.directive.ts
@@ -1,45 +1,48 @@
-import { Directive, ElementRef, HostListener, OnInit, Renderer2 } from '@angular/core';
-import { LenisService } from '../services/lenis.service';
+import { Directive, ElementRef, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ScrollService } from '../services/scroll.service';
 
 @Directive({
   selector: '[appNavbarScroll]',
   standalone: true,
 })
-export class NavbarScrollDirective {
+export class NavbarScrollDirective implements OnInit, OnDestroy {
   private lastScrollTop = 0;
   private isHidden = false;
-  
+  private destroy$ = new Subject<void>();
 
-  constructor(private el: ElementRef, private renderer: Renderer2) {}
+  constructor(
+    private el: ElementRef,
+    private renderer: Renderer2,
+    private scrollService: ScrollService
+  ) {}
 
-  @HostListener('window:scroll', [])
-  onWindowScroll() {
-    const currentScroll =
-      window.pageYOffset || document.documentElement.scrollTop;
+  ngOnInit(): void {
+    this.scrollService.scrollY$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((scrollTop) => {
+        this.handleScroll(scrollTop);
+      });
+  }
 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private handleScroll(currentScroll: number) {
     // scroll down → hide navbar
-    if (
-      currentScroll > this.lastScrollTop &&
-      currentScroll > 50 &&
-      !this.isHidden
-    ) {
+    if (currentScroll > this.lastScrollTop && currentScroll > 50 && !this.isHidden) {
       this.isHidden = true;
-      this.renderer.setStyle(
-        this.el.nativeElement,
-        'transform',
-        'translateY(-120%)'
-      );
+      this.renderer.setStyle(this.el.nativeElement, 'transform', 'translateY(-120%)');
       this.renderer.setStyle(this.el.nativeElement, 'opacity', '0');
       this.renderer.setStyle(this.el.nativeElement, 'pointerEvents', 'none');
     }
     // scroll up → show navbar
     else if (currentScroll < this.lastScrollTop && this.isHidden) {
       this.isHidden = false;
-      this.renderer.setStyle(
-        this.el.nativeElement,
-        'transform',
-        'translateY(0)'
-      );
+      this.renderer.setStyle(this.el.nativeElement, 'transform', 'translateY(0)');
       this.renderer.setStyle(this.el.nativeElement, 'opacity', '1');
       this.renderer.setStyle(this.el.nativeElement, 'pointerEvents', 'auto');
     }

--- a/frontend/ashaven-ui/src/app/pages/about/hero-section/hero-section.component.html
+++ b/frontend/ashaven-ui/src/app/pages/about/hero-section/hero-section.component.html
@@ -3,7 +3,7 @@
       <div
         class="absolute -top-16 left-0 h-[120%] w-full bg-cover bg-center transition-transform duration-500"
         style="background-image: url('/images/banner/banner-3.png')"
-        [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.3 - 60) + 'px)' }"
+        [style.transform]="scrollTransform"
       ></div>
       <div class="absolute inset-0 bg-gradient-to-br from-emerald-950/85 via-emerald-900/70 to-brand/70"></div>
     </div>

--- a/frontend/ashaven-ui/src/app/pages/about/hero-section/hero-section.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/about/hero-section/hero-section.component.ts
@@ -1,6 +1,9 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, NgZone, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ScrollService } from '../../../services/scroll.service';
 
 @Component({
   selector: 'app-hero-section',
@@ -9,11 +12,25 @@ import { RouterLink } from '@angular/router';
   templateUrl: './hero-section.component.html',
   styleUrl: './hero-section.component.css',
 })
-export class HeroSectionComponent {
-  scrollY = 0;
+export class HeroSectionComponent implements OnDestroy {
+  scrollTransform = 'translateY(-60px)';
+  private destroy$ = new Subject<void>();
 
-  @HostListener('window:scroll', ['$event'])
-  onWindowScroll() {
-    this.scrollY = window.scrollY;
+  constructor(private scrollService: ScrollService, private zone: NgZone) {
+    this.scrollService.scrollY$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((scrollY) => {
+        const transform = `translateY(${scrollY * 0.3 - 60}px)`;
+        if (transform !== this.scrollTransform) {
+          this.zone.run(() => {
+            this.scrollTransform = transform;
+          });
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.html
+++ b/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.html
@@ -6,7 +6,7 @@
       <div
         class="absolute -top-16 left-0 h-[120%] w-full bg-cover bg-center transition-transform duration-500"
         style="background-image: url('/images/banner/banner-3.png')"
-        [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.3 - 60) + 'px)' }"
+        [style.transform]="scrollTransform"
       ></div>
       <div class="absolute inset-0 bg-gradient-to-br from-emerald-950/85 via-emerald-900/70 to-brand/70"></div>
     </div>

--- a/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/contact/contact-hero/contact-hero.component.ts
@@ -1,6 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, HostListener } from '@angular/core';
+import { Component, NgZone, OnDestroy } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ScrollService } from '../../../services/scroll.service';
 
 @Component({
   selector: 'app-contact-hero',
@@ -9,11 +12,25 @@ import { RouterModule } from '@angular/router';
   templateUrl: './contact-hero.component.html',
   styleUrl: './contact-hero.component.css',
 })
-export class ContactHeroComponent {
-  scrollY = 0;
+export class ContactHeroComponent implements OnDestroy {
+  scrollTransform = 'translateY(-60px)';
+  private destroy$ = new Subject<void>();
 
-  @HostListener('window:scroll', ['$event'])
-  onWindowScroll() {
-    this.scrollY = window.scrollY;
+  constructor(private scrollService: ScrollService, private zone: NgZone) {
+    this.scrollService.scrollY$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((scrollY) => {
+        const transform = `translateY(${scrollY * 0.3 - 60}px)`;
+        if (transform !== this.scrollTransform) {
+          this.zone.run(() => {
+            this.scrollTransform = transform;
+          });
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.html
@@ -6,7 +6,7 @@
       <div
         class="absolute -top-16 left-0 h-[120%] w-full bg-cover bg-center transition-transform duration-500"
         style="background-image: url('/images/banner/banner-3.png')"
-        [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.3 - 60) + 'px)' }"
+        [style.transform]="scrollTransform"
       ></div>
       <div class="absolute inset-0 bg-gradient-to-br from-emerald-950/85 via-emerald-900/70 to-brand/70"></div>
     </div>

--- a/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/gallery-page/gallery-hero/gallery-hero.component.ts
@@ -1,6 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, HostListener } from '@angular/core';
+import { Component, NgZone, OnDestroy } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ScrollService } from '../../../services/scroll.service';
 
 @Component({
   selector: 'app-gallery-hero',
@@ -9,11 +12,25 @@ import { RouterModule } from '@angular/router';
   templateUrl: './gallery-hero.component.html',
   styleUrl: './gallery-hero.component.css',
 })
-export class GalleryHeroComponent {
-  scrollY = 0;
+export class GalleryHeroComponent implements OnDestroy {
+  scrollTransform = 'translateY(-60px)';
+  private destroy$ = new Subject<void>();
 
-  @HostListener('window:scroll', ['$event'])
-  onWindowScroll() {
-    this.scrollY = window.scrollY;
+  constructor(private scrollService: ScrollService, private zone: NgZone) {
+    this.scrollService.scrollY$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((scrollY) => {
+        const transform = `translateY(${scrollY * 0.3 - 60}px)`;
+        if (transform !== this.scrollTransform) {
+          this.zone.run(() => {
+            this.scrollTransform = transform;
+          });
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/project/project.component.html
+++ b/frontend/ashaven-ui/src/app/pages/project/project.component.html
@@ -4,7 +4,7 @@
       <div
         class="absolute -top-16 left-0 h-[125%] w-full bg-cover bg-center transition-transform duration-500"
         style="background-image: url('/images/banner/banner-3.png')"
-        [ngStyle]="{ transform: 'translateY(' + (scrollY * 0.3 - 60) + 'px)' }"
+        [style.transform]="scrollTransform"
       ></div>
       <div class="absolute inset-0 bg-gradient-to-br from-emerald-950/85 via-emerald-900/70 to-brand/70"></div>
     </div>

--- a/frontend/ashaven-ui/src/app/pages/project/project.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project/project.component.ts
@@ -3,7 +3,8 @@ import {
   ViewChild,
   ElementRef,
   AfterViewInit,
-  HostListener,
+  NgZone,
+  OnDestroy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
@@ -11,6 +12,9 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { ToastrService } from 'ngx-toastr';
 // import { LenisService } from '../../services/lenis.service';
+import { ScrollService } from '../../services/scroll.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 interface ProjectItem {
   id: number | string;
@@ -30,23 +34,38 @@ interface ProjectItem {
   templateUrl: './project.component.html',
   styleUrls: ['./project.component.css'],
 })
-export class ProjectsComponent implements AfterViewInit {
+export class ProjectsComponent implements AfterViewInit, OnDestroy {
   @ViewChild('categorySelect') categorySelect!: ElementRef<HTMLSelectElement>;
   @ViewChild('typeSelect') typeSelect!: ElementRef<HTMLSelectElement>;
 
-  scrollY = 0;
+  scrollTransform = 'translateY(-60px)';
   baseUrl = environment.baseUrl;
 
   state = {
     list: [] as ProjectItem[],
   };
 
+  private destroy$ = new Subject<void>();
+
   constructor(
     private http: HttpClient,
     // private lenisService: LenisService,
     private toastr: ToastrService,
-    private route: ActivatedRoute
-  ) {}
+    private route: ActivatedRoute,
+    private scrollService: ScrollService,
+    private zone: NgZone
+  ) {
+    this.scrollService.scrollY$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((scrollY) => {
+        const transform = `translateY(${scrollY * 0.3 - 60}px)`;
+        if (transform !== this.scrollTransform) {
+          this.zone.run(() => {
+            this.scrollTransform = transform;
+          });
+        }
+      });
+  }
 
   ngAfterViewInit(): void {
     // Read category from query params (e.g., /projects?category=Ongoing)
@@ -116,8 +135,8 @@ export class ProjectsComponent implements AfterViewInit {
     }
   }
 
-  @HostListener('window:scroll', ['$event'])
-  onWindowScroll() {
-    this.scrollY = window.scrollY;
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/frontend/ashaven-ui/src/app/services/scroll.service.ts
+++ b/frontend/ashaven-ui/src/app/services/scroll.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, NgZone } from '@angular/core';
+import { Observable, of, fromEvent } from 'rxjs';
+import { map, startWith, throttleTime, distinctUntilChanged, shareReplay } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ScrollService {
+  readonly scrollY$: Observable<number>;
+
+  constructor(private zone: NgZone) {
+    if (typeof window === 'undefined') {
+      this.scrollY$ = of(0);
+      return;
+    }
+
+    this.scrollY$ = this.zone.runOutsideAngular(() =>
+      fromEvent(window, 'scroll', { passive: true }).pipe(
+        throttleTime(50, undefined, { leading: true, trailing: true }),
+        map(() => window.scrollY || window.pageYOffset || 0),
+        startWith(window.scrollY || window.pageYOffset || 0),
+        distinctUntilChanged(),
+        shareReplay({ bufferSize: 1, refCount: true })
+      )
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `ScrollService` that throttles scroll position updates outside Angular change detection
- refactor scroll-aware components and directives to subscribe to the shared stream and update state only when values change
- replace inline parallax bindings to use the cached transforms produced by the service

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea39ea9ff88323978ffbde55a5d84b