### PR TITLE
Remove ScrollService and smooth scrolling behaviors

### DIFF
--- a/frontend/ashaven-ui/src/app/components/follow-update/follow-update.component.ts
+++ b/frontend/ashaven-ui/src/app/components/follow-update/follow-update.component.ts
@@ -39,7 +39,6 @@ export class FollowUpdateComponent {
       this.scrollAmount = Math.max(this.scrollAmount - this.scrollStep, 0);
       this.scrollContainer.scrollTo({
         left: this.scrollAmount,
-        behavior: 'smooth',
       });
     }
   }
@@ -50,7 +49,6 @@ export class FollowUpdateComponent {
       this.scrollAmount = Math.min(this.scrollAmount + this.scrollStep, maxScroll);
       this.scrollContainer.scrollTo({
         left: this.scrollAmount,
-        behavior: 'smooth',
       });
     }
   }

--- a/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.ts
+++ b/frontend/ashaven-ui/src/app/components/hero-slide/hero-slide.component.ts
@@ -157,7 +157,6 @@ export class HeroSlideComponent implements OnInit, OnDestroy, AfterViewInit {
     el.scrollIntoView({
       block: 'nearest',
       inline: 'nearest',
-      behavior: 'smooth',
     });
   }
 }

--- a/frontend/ashaven-ui/src/app/components/navbar/navbar.component.ts
+++ b/frontend/ashaven-ui/src/app/components/navbar/navbar.component.ts
@@ -50,7 +50,7 @@ export class NavbarComponent {
     // if (this.lenisService.lenis) {
     //   this.lenisService.lenis.scrollTo(`#${sectionId}`, { duration: 0.8 });
     // } else {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      document.getElementById(sectionId)?.scrollIntoView({ block: 'start' });
     // }
 
     this.sidePanel.close();

--- a/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
+++ b/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
@@ -46,6 +46,6 @@ export class ScrollToTopComponent {
   }
 
   scrollToTop() {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0 });
   }
 }

--- a/frontend/ashaven-ui/src/app/components/side-panel/side-panel.component.ts
+++ b/frontend/ashaven-ui/src/app/components/side-panel/side-panel.component.ts
@@ -22,7 +22,7 @@ export class SidePanelComponent implements OnDestroy {
     // if (this.lenisService.lenis) {
     //   this.lenisService.lenis.scrollTo(`#${sectionId}`, { duration: 0.8 });
     // } else {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      document.getElementById(sectionId)?.scrollIntoView({ block: 'start' });
     
     this.sidePanel.close();
   }

--- a/frontend/ashaven-ui/src/app/pages/project-details/project-details.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/project-details.component.ts
@@ -277,7 +277,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   scrollToContactForm() {
     const contactForm = document.getElementById('contacting');
     if (contactForm) {
-      contactForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      contactForm.scrollIntoView({ block: 'start' });
     }
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/project-details/related-projects/related-projects.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/related-projects/related-projects.component.ts
@@ -60,7 +60,7 @@ export class RelatedProjectsComponent implements OnChanges {
         onSameUrlNavigation: 'reload',
       })
       .then(() => {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        window.scrollTo({ top: 0 });
       })
       .catch((err) => console.error('Navigation error:', err));
   }

--- a/frontend/ashaven-ui/src/app/pages/project-details/swiper-slider/swiper-slider.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/swiper-slider/swiper-slider.component.ts
@@ -214,7 +214,7 @@ export class SwiperSliderComponent
         onSameUrlNavigation: 'reload',
       })
       .then(() => {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        window.scrollTo({ top: 0 });
       })
       .catch((err) => console.error('Navigation error:', err));
   }

--- a/frontend/ashaven-ui/src/app/pages/project-details/tab-bar/tab-bar.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/tab-bar/tab-bar.component.ts
@@ -50,7 +50,7 @@ export class TabBarComponent {
   scrollToSection(sectionId: string) {
     const element = document.getElementById(sectionId);
     if (element) {
-      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      element.scrollIntoView({ block: 'start' });
       this.activeTab = sectionId;
     }
   }


### PR DESCRIPTION
## Summary
- revert the ScrollService integration so scroll-aware components use direct HostListener updates
- restore hero and project parallax bindings to compute from component scroll state
- remove smooth scrolling behavior from navigation helpers to avoid extra animation work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea39ea9ff88323978ffbde55a5d84b