### PR TITLE
Enable Lenis-based smooth scrolling throughout the UI

### DIFF
--- a/frontend/ashaven-ui/src/app/components/navbar/navbar.component.ts
+++ b/frontend/ashaven-ui/src/app/components/navbar/navbar.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostListener, OnDestroy, OnInit, NgZone } from '@angular/core';
 import { CommonModule } from '@angular/common';
-// import { LenisService } from '../../services/lenis.service';
+import { LenisService } from '../../services/lenis.service';
 import { SidePanelComponent } from '../side-panel/side-panel.component';
 import { SidePanelService } from '../../services/sidepanel.service';
 import { RouterLink, Router } from '@angular/router';
@@ -21,7 +21,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   constructor(
     public sidePanel: SidePanelService,
-    // private lenisService: LenisService,
+    private lenisService: LenisService,
     public router: Router,
     private scrollService: ScrollService,
     private zone: NgZone
@@ -63,11 +63,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   scrollToSection(sectionId: string) {
-    // if (this.lenisService.lenis) {
-    //   this.lenisService.lenis.scrollTo(`#${sectionId}`, { duration: 0.8 });
-    // } else {
-      document.getElementById(sectionId)?.scrollIntoView({ block: 'start' });
-    // }
+    this.lenisService.scrollTo(`#${sectionId}`, { duration: 0.8 });
 
     this.sidePanel.close();
   }

--- a/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
+++ b/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
@@ -10,6 +10,7 @@ import {
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ScrollService } from '../../services/scroll.service';
+import { LenisService } from '../../services/lenis.service';
 
 @Component({
   selector: 'app-scroll-to-top',
@@ -44,7 +45,11 @@ export class ScrollToTopComponent implements OnInit, OnDestroy {
   isVisible = false;
   private destroy$ = new Subject<void>();
 
-  constructor(private scrollService: ScrollService, private zone: NgZone) {}
+  constructor(
+    private scrollService: ScrollService,
+    private lenisService: LenisService,
+    private zone: NgZone
+  ) {}
 
   ngOnInit(): void {
     this.scrollService.scrollY$
@@ -65,6 +70,6 @@ export class ScrollToTopComponent implements OnInit, OnDestroy {
   }
 
   scrollToTop() {
-    window.scrollTo({ top: 0 });
+    this.lenisService.scrollTo(0, { duration: 0.8 });
   }
 }

--- a/frontend/ashaven-ui/src/app/components/side-panel/side-panel.component.ts
+++ b/frontend/ashaven-ui/src/app/components/side-panel/side-panel.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-// import { LenisService } from '../../services/lenis.service';
+import { LenisService } from '../../services/lenis.service';
 import { SidePanelService } from '../../services/sidepanel.service';
 import { Router, RouterLink } from '@angular/router';
 
@@ -14,16 +14,12 @@ import { Router, RouterLink } from '@angular/router';
 export class SidePanelComponent implements OnDestroy {
   constructor(
     public sidePanel: SidePanelService,
-    // private lenisService: LenisService,
+    private lenisService: LenisService,
     private router: Router
   ) {}
 
   scrollToSection(sectionId: string) {
-    // if (this.lenisService.lenis) {
-    //   this.lenisService.lenis.scrollTo(`#${sectionId}`, { duration: 0.8 });
-    // } else {
-      document.getElementById(sectionId)?.scrollIntoView({ block: 'start' });
-    
+    this.lenisService.scrollTo(`#${sectionId}`, { duration: 0.8 });
     this.sidePanel.close();
   }
 

--- a/frontend/ashaven-ui/src/app/pages/project-details/project-details.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/project-details.component.ts
@@ -4,7 +4,7 @@ import { RouterModule } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
-// import { LenisService } from '../../services/lenis.service';
+import { LenisService } from '../../services/lenis.service';
 import { ProjectHeaderComponent } from './project-header/project-header.component';
 import { OfferTimerComponent } from './offer-timer/offer-timer.component';
 import { MarqueeComponent } from './marquee/marquee.component';
@@ -82,7 +82,7 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
     private http: HttpClient,
     private route: ActivatedRoute,
     private toastr: ToastrService,
-    // private lenisService: LenisService
+    private lenisService: LenisService
   ) {}
 
   ngOnInit(): void {
@@ -275,9 +275,6 @@ export class ProjectDetailsComponent implements OnInit, OnDestroy {
   }
 
   scrollToContactForm() {
-    const contactForm = document.getElementById('contacting');
-    if (contactForm) {
-      contactForm.scrollIntoView({ block: 'start' });
-    }
+    this.lenisService.scrollTo('#contacting', { duration: 0.8 });
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/project-details/related-projects/related-projects.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/related-projects/related-projects.component.ts
@@ -8,6 +8,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { RouterModule, Router } from '@angular/router';
+import { LenisService } from '../../../services/lenis.service';
 
 interface ProjectCard {
   id: number;
@@ -31,7 +32,7 @@ export class RelatedProjectsComponent implements OnChanges {
 
   cards: ProjectCard[] = [];
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private lenisService: LenisService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['projects'] && this.projects) {
@@ -60,7 +61,7 @@ export class RelatedProjectsComponent implements OnChanges {
         onSameUrlNavigation: 'reload',
       })
       .then(() => {
-        window.scrollTo({ top: 0 });
+        this.lenisService.scrollTo(0, { duration: 0.8 });
       })
       .catch((err) => console.error('Navigation error:', err));
   }

--- a/frontend/ashaven-ui/src/app/pages/project-details/swiper-slider/swiper-slider.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/swiper-slider/swiper-slider.component.ts
@@ -12,6 +12,7 @@ import { RouterModule, Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
 import { ProjectService } from '../../../services/project.service';
 import { Project } from '../../../models/model';
+import { LenisService } from '../../../services/lenis.service';
 
 interface Slide {
   id: string;
@@ -64,7 +65,8 @@ export class SwiperSliderComponent
   constructor(
     private projectService: ProjectService,
     private router: Router,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private lenisService: LenisService
   ) {}
 
   ngOnInit() {
@@ -214,7 +216,7 @@ export class SwiperSliderComponent
         onSameUrlNavigation: 'reload',
       })
       .then(() => {
-        window.scrollTo({ top: 0 });
+        this.lenisService.scrollTo(0, { duration: 0.8 });
       })
       .catch((err) => console.error('Navigation error:', err));
   }

--- a/frontend/ashaven-ui/src/app/pages/project-details/tab-bar/tab-bar.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/project-details/tab-bar/tab-bar.component.ts
@@ -3,6 +3,7 @@ import { CommonModule, TitleCasePipe } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ScrollService } from '../../../services/scroll.service';
+import { LenisService } from '../../../services/lenis.service';
 
 @Component({
   selector: 'app-tab-bar',
@@ -28,7 +29,11 @@ export class TabBarComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
 
-  constructor(private scrollService: ScrollService, private zone: NgZone) {}
+  constructor(
+    private scrollService: ScrollService,
+    private lenisService: LenisService,
+    private zone: NgZone
+  ) {}
 
   ngOnInit(): void {
     this.scrollService.scrollY$
@@ -78,10 +83,7 @@ export class TabBarComponent implements OnInit, OnDestroy {
   }
 
   scrollToSection(sectionId: string) {
-    const element = document.getElementById(sectionId);
-    if (element) {
-      element.scrollIntoView({ block: 'start' });
-      this.activeTab = sectionId;
-    }
+    this.lenisService.scrollTo(`#${sectionId}`, { duration: 0.8 });
+    this.activeTab = sectionId;
   }
 }

--- a/frontend/ashaven-ui/src/app/services/lenis.service.ts
+++ b/frontend/ashaven-ui/src/app/services/lenis.service.ts
@@ -1,150 +1,207 @@
-// import { Injectable, NgZone, inject } from '@angular/core';
-// import { NavigationEnd, Router } from '@angular/router';
-// import { filter } from 'rxjs/operators';
-// import Lenis from '@studio-freight/lenis';
+import { Injectable, NgZone } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { BehaviorSubject, Observable, fromEvent, of } from 'rxjs';
+import { distinctUntilChanged, filter, map, shareReplay, startWith } from 'rxjs/operators';
+import Lenis from '@studio-freight/lenis';
 
-// type ScrollEvent = { scroll: number };
+type ScrollEvent = { scroll: number };
 
-// @Injectable({ providedIn: 'root' })
-// export class LenisService {
-//   public lenis?: Lenis;
-//   private router = inject(Router);
-//   private ngZone = inject(NgZone);
-//   private rafId?: number;
-//   private motionQuery?: MediaQueryList;
-//   private viewportQuery?: MediaQueryList;
+type ScrollTarget = Parameters<Lenis['scrollTo']>[0];
+type LenisScrollToOptions = Parameters<Lenis['scrollTo']>[1];
 
-//   constructor() {
-//     if (typeof window === 'undefined') {
-//       return;
-//     }
+@Injectable({ providedIn: 'root' })
+export class LenisService {
+  public lenis?: Lenis;
 
-//     this.motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-//     const motionQuery = this.motionQuery;
-//     const handleMotionPreference = (event: MediaQueryListEvent) => {
-//       if (event.matches) {
-//         this.stopLenis();
-//       } else {
-//         this.init();
-//       }
-//     };
+  private readonly scrollSubject = new BehaviorSubject<number>(0);
+  private readonly windowScroll$?: Observable<number>;
+  private motionQuery?: MediaQueryList;
+  private rafId?: number;
+  private lenisScrollCallback?: (event: ScrollEvent) => void;
 
-//     if (typeof motionQuery.addEventListener === 'function') {
-//       motionQuery.addEventListener('change', handleMotionPreference);
-//     } else if (typeof motionQuery.addListener === 'function') {
-//       // Safari < 14 fallback
-//       motionQuery.addListener(handleMotionPreference);
-//     }
+  readonly scroll$: Observable<number> = this.scrollSubject.asObservable();
 
-//     this.viewportQuery = window.matchMedia('(max-width: 767px)');
-//     const viewportQuery = this.viewportQuery;
-//     const handleViewportChange = (event: MediaQueryListEvent) => {
-//       if (event.matches) {
-//         this.stopLenis();
-//       } else {
-//         this.init();
-//       }
-//     };
+  constructor(private router: Router, private ngZone: NgZone) {
+    if (typeof window === 'undefined') {
+      this.windowScroll$ = of(0);
+      return;
+    }
 
-//     if (typeof viewportQuery.addEventListener === 'function') {
-//       viewportQuery.addEventListener('change', handleViewportChange);
-//     } else if (typeof viewportQuery.addListener === 'function') {
-//       viewportQuery.addListener(handleViewportChange);
-//     }
+    this.motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    this.windowScroll$ = fromEvent(window, 'scroll', { passive: true }).pipe(
+      startWith(window.scrollY || window.pageYOffset || 0),
+      map(() => window.scrollY || window.pageYOffset || 0),
+      distinctUntilChanged(),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
 
-//     this.init();
-//     this.handleRouteChange();
-//   }
+    this.scrollSubject.next(window.scrollY || window.pageYOffset || 0);
 
-//   public init(): void {
-//     if (typeof window === 'undefined') {
-//       return;
-//     }
+    const handleMotionPreference = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        this.stopLenis();
+      } else {
+        this.init();
+      }
+    };
 
-//     const root = document.documentElement;
-//     const body = document.body;
-//     root.style.scrollBehavior = 'auto';
-//     body.style.scrollBehavior = 'auto';
+    if (typeof this.motionQuery.addEventListener === 'function') {
+      this.motionQuery.addEventListener('change', handleMotionPreference);
+    } else if (typeof this.motionQuery.addListener === 'function') {
+      this.motionQuery.addListener(handleMotionPreference);
+    }
 
-//     const prefersReducedMotion = this.motionQuery ?? window.matchMedia('(prefers-reduced-motion: reduce)');
-//     if (prefersReducedMotion.matches) {
-//       this.stopLenis();
-//       return;
-//     }
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe(() => {
+        if (!this.lenis) {
+          window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+          this.scrollSubject.next(0);
+          return;
+        }
 
-//     const prefersTouchInput = window.matchMedia('(pointer: coarse)').matches;
+        this.lenis.scrollTo(0, { immediate: true });
+      });
 
-//     this.stopLenis();
+    this.handleFallbackScroll();
+    this.init();
+  }
 
-//     if (prefersTouchInput) {
-//       return;
-//     }
+  init(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
 
-//     this.lenis = new Lenis({
-//       duration: 1.05,
-//       easing: (t: number) => 1 - Math.pow(1 - t, 3),
-//       smoothWheel: true,
-//       touchMultiplier: 1.1,
-//       lerp: 0.075,
-//     });
+    if (!this.shouldUseLenis()) {
+      this.stopLenis();
+      return;
+    }
 
-//     root.classList.add('has-lenis');
-//     body.classList.add('has-lenis');
+    const root = document.documentElement;
+    const body = document.body;
+    root.style.scrollBehavior = 'auto';
+    body.style.scrollBehavior = 'auto';
 
-//     const runRaf = (time: number) => {
-//       this.lenis?.raf(time);
-//       this.scheduleRaf(runRaf);
-//     };
+    this.stopLenis();
 
-//     this.scheduleRaf(runRaf);
-//   }
+    this.lenis = new Lenis({
+      duration: 1.05,
+      easing: (t: number) => 1 - Math.pow(1 - t, 3),
+      smoothWheel: true,
+      touchMultiplier: 1.1,
+      lerp: 0.075,
+    });
 
-//   private stopLenis(): void {
-//     if (this.rafId) {
-//       cancelAnimationFrame(this.rafId);
-//       this.rafId = undefined;
-//     }
+    root.classList.add('has-lenis');
+    body.classList.add('has-lenis');
 
-//     document.documentElement.classList.remove('has-lenis');
-//     document.body.classList.remove('has-lenis');
+    this.lenisScrollCallback = (event: ScrollEvent) => {
+      this.scrollSubject.next(event.scroll);
+    };
 
-//     this.lenis?.destroy();
-//     this.lenis = undefined;
-//   }
+    this.lenis.on('scroll', this.lenisScrollCallback);
 
-//   private scheduleRaf(callback: FrameRequestCallback): void {
-//     this.ngZone.runOutsideAngular(() => {
-//       this.rafId = requestAnimationFrame(callback);
-//     });
-//   }
+    const runRaf = (time: number) => {
+      this.lenis?.raf(time);
+      this.scheduleRaf(runRaf);
+    };
 
-//   private handleRouteChange(): void {
-//     this.router.events
-//       .pipe(filter((event) => event instanceof NavigationEnd))
-//       .subscribe(() => {
-//         if (!this.lenis) {
-//           window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
-//           return;
-//         }
+    this.scheduleRaf(runRaf);
+  }
 
-//         this.lenis.scrollTo(0, { immediate: true });
-//       });
-//   }
+  onScroll(callback: (scroll: number) => void): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.scroll$.pipe(distinctUntilChanged()).subscribe(callback);
+    });
+  }
 
-//   onScroll(callback: (scroll: number) => void): void {
-//     if (this.lenis) {
-//       this.lenis.on('scroll', (event: ScrollEvent) => {
-//         callback(event.scroll);
-//       });
-//       return;
-//     }
+  scrollTo(target: ScrollTarget, options?: LenisScrollToOptions): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
 
-//     if (typeof window !== 'undefined') {
-//       window.addEventListener(
-//         'scroll',
-//         () => callback(window.scrollY || window.pageYOffset || 0),
-//         { passive: true }
-//       );
-//     }
-//   }
-// }
+    if (this.lenis) {
+      this.lenis.scrollTo(target, options);
+      return;
+    }
+
+    const top = this.resolveTarget(target);
+    const behavior: ScrollBehavior = this.motionQuery?.matches ? 'auto' : 'smooth';
+    window.scrollTo({ top, behavior });
+  }
+
+  private resolveTarget(target: ScrollTarget): number {
+    if (typeof target === 'number') {
+      return target;
+    }
+
+    if (typeof target === 'string') {
+      const element = document.querySelector(target);
+      if (element instanceof HTMLElement) {
+        return element.getBoundingClientRect().top + (window.scrollY || window.pageYOffset || 0);
+      }
+      return 0;
+    }
+
+    if (target instanceof HTMLElement) {
+      return target.getBoundingClientRect().top + (window.scrollY || window.pageYOffset || 0);
+    }
+
+    return 0;
+  }
+
+  private shouldUseLenis(): boolean {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    const prefersReducedMotion = this.motionQuery ?? window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (prefersReducedMotion.matches) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private stopLenis(): void {
+    if (this.rafId) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = undefined;
+    }
+
+    document.documentElement.classList.remove('has-lenis');
+    document.body.classList.remove('has-lenis');
+
+    if (this.lenisScrollCallback && this.lenis) {
+      this.lenis.off('scroll', this.lenisScrollCallback);
+    }
+    this.lenisScrollCallback = undefined;
+
+    this.lenis?.destroy();
+    this.lenis = undefined;
+
+    if (typeof window !== 'undefined') {
+      this.scrollSubject.next(window.scrollY || window.pageYOffset || 0);
+    }
+  }
+
+  private scheduleRaf(callback: FrameRequestCallback): void {
+    this.ngZone.runOutsideAngular(() => {
+      this.rafId = requestAnimationFrame(callback);
+    });
+  }
+
+  private handleFallbackScroll(): void {
+    const windowScroll$ = this.windowScroll$;
+
+    if (!windowScroll$) {
+      return;
+    }
+
+    this.ngZone.runOutsideAngular(() => {
+      windowScroll$
+        .pipe(filter(() => !this.lenis))
+        .subscribe((scrollY) => this.scrollSubject.next(scrollY));
+    });
+  }
+}

--- a/frontend/ashaven-ui/src/app/services/scroll.service.ts
+++ b/frontend/ashaven-ui/src/app/services/scroll.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NgZone } from '@angular/core';
-import { Observable, of, fromEvent } from 'rxjs';
-import { map, startWith, throttleTime, distinctUntilChanged, shareReplay } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { distinctUntilChanged, shareReplay, throttleTime } from 'rxjs/operators';
+import { LenisService } from './lenis.service';
 
 @Injectable({
   providedIn: 'root',
@@ -8,17 +9,15 @@ import { map, startWith, throttleTime, distinctUntilChanged, shareReplay } from 
 export class ScrollService {
   readonly scrollY$: Observable<number>;
 
-  constructor(private zone: NgZone) {
+  constructor(private zone: NgZone, private lenisService: LenisService) {
     if (typeof window === 'undefined') {
       this.scrollY$ = of(0);
       return;
     }
 
     this.scrollY$ = this.zone.runOutsideAngular(() =>
-      fromEvent(window, 'scroll', { passive: true }).pipe(
+      this.lenisService.scroll$.pipe(
         throttleTime(50, undefined, { leading: true, trailing: true }),
-        map(() => window.scrollY || window.pageYOffset || 0),
-        startWith(window.scrollY || window.pageYOffset || 0),
         distinctUntilChanged(),
         shareReplay({ bufferSize: 1, refCount: true })
       )

--- a/frontend/ashaven-ui/src/main.ts
+++ b/frontend/ashaven-ui/src/main.ts
@@ -4,7 +4,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideToastr } from 'ngx-toastr';
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
-// import { LenisService } from './app/services/lenis.service';
+import { LenisService } from './app/services/lenis.service';
 import { register } from 'swiper/element/bundle';
 import 'aos/dist/aos.css';
 
@@ -17,6 +17,6 @@ bootstrapApplication(AppComponent, {
     provideAnimations(),
     provideHttpClient(),
     provideToastr(),
-    // LenisService
+    LenisService,
   ],
 }).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- restore and wire up the Lenis service to drive smooth scrolling and expose shared scroll state
- update navigation, project details, and related components to use Lenis for section jumps and return-to-top interactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea42349dec8323beb8ac19164f20af