### PR TITLE
Fix mobile scrolling and simplify dashboard palette

### DIFF
--- a/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.css
+++ b/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.css
@@ -12,7 +12,14 @@
   cursor: pointer;
   box-shadow: 0 18px 35px rgba(255, 119, 27, 0.35);
   z-index: 999;
-  transition: background-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(30px);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease, background-color 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .scroll-to-top:hover,
@@ -20,4 +27,10 @@
   background-color: var(--luxe-amber-soft);
   transform: translateY(-4px);
   box-shadow: 0 25px 55px rgba(255, 119, 27, 0.4);
+}
+
+.scroll-to-top--visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }

--- a/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.html
+++ b/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.html
@@ -1,7 +1,9 @@
 <button
-  [@buttonState]="isVisible ? 'visible' : 'hidden'"
-  (click)="scrollToTop()"
+  type="button"
   class="scroll-to-top"
+  [class.scroll-to-top--visible]="isVisible"
+  (click)="scrollToTop()"
+  aria-label="Scroll back to top"
 >
-  ↑
+  <span aria-hidden="true">↑</span>
 </button>

--- a/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
+++ b/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
@@ -6,13 +6,6 @@ import {
   OnInit,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import {
-  trigger,
-  state,
-  style,
-  transition,
-  animate,
-} from '@angular/animations';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ScrollService } from '../../services/scroll.service';
@@ -24,28 +17,6 @@ import { LenisService } from '../../services/lenis.service';
   imports: [CommonModule],
   templateUrl: './scroll-to-top.component.html',
   styleUrls: ['./scroll-to-top.component.css'],
-  animations: [
-    trigger('buttonState', [
-      state(
-        'hidden',
-        style({
-          opacity: 0,
-          transform: 'translateY(-1000px)',
-          pointerEvents: 'none',
-        })
-      ),
-      state(
-        'visible',
-        style({
-          opacity: 1,
-          transform: 'translateY(0)',
-          pointerEvents: 'auto',
-        })
-      ),
-      transition('hidden => visible', [animate('300ms ease-out')]),
-      transition('visible => hidden', [animate('300ms ease-in')]),
-    ]),
-  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ScrollToTopComponent implements OnInit, OnDestroy {

--- a/frontend/ashaven-ui/src/app/features/dashboard/dashboard-home/dashboard-home.component.html
+++ b/frontend/ashaven-ui/src/app/features/dashboard/dashboard-home/dashboard-home.component.html
@@ -1,10 +1,10 @@
 <section class="grid gap-8 md:gap-10">
   <!-- HERO -->
   <header
-    class="flex flex-wrap items-center justify-between gap-6 md:gap-10 rounded-xl border border-emerald-50/10 bg-brand p-6 md:p-8 shadow-xl"
+    class="flex flex-wrap items-center justify-between gap-6 md:gap-10 rounded-xl border border-slate-200 bg-white p-6 md:p-8 shadow-sm"
   >
     <div class="max-w-2xl">
-      <span class="uppercase tracking-wider text-xs text-emerald-100/70">Portfolio Intelligence</span>
+      <span class="uppercase tracking-wider text-xs text-slate-500">Portfolio Intelligence</span>
       <h1 class="font-serif text-[1.8rem] md:text-4xl leading-tight mt-2 mb-4">
         Your luxury real estate command centre
       </h1>
@@ -14,17 +14,17 @@
   <!-- MAIN GRID: Left = Active portfolio, Right = Metrics stacked -->
   <div class="grid gap-6 lg:grid-cols-2">
     <!-- Left: Active portfolio -->
-    <section class="grid gap-5 rounded-xl border border-emerald-50/10 bg-brand p-6 md:p-8 shadow-xl">
+    <section class="grid gap-5 rounded-xl border border-slate-200 bg-white p-6 md:p-8 shadow-sm">
       <header class="flex items-start justify-between gap-4">
         <h2 class="font-serif text-xl">Active portfolio</h2>
-        <a routerLink="/dashboard/projects" class="text-emerald-300 hover:text-emerald-200 underline underline-offset-4">
+        <a routerLink="/dashboard/projects" class="text-brand hover:opacity-80 underline underline-offset-4">
           View all listings
         </a>
       </header>
 
-      <div class="overflow-x-auto rounded-lg border border-emerald-50/10">
+      <div class="overflow-x-auto rounded-lg border border-slate-200">
         <table class="w-full min-w-[520px] border-collapse text-left">
-          <thead class="bg-emerald-50/10 uppercase tracking-wider text-[0.72rem]">
+          <thead class="bg-slate-100 uppercase tracking-wider text-[0.72rem] text-slate-600">
             <tr>
               <th class="py-3 px-4">Residence</th>
               <th class="py-3 px-4">Location</th>
@@ -32,7 +32,7 @@
               <th class="py-3 px-4">Published</th>
             </tr>
           </thead>
-          <tbody class="[&_tr:nth-child(even)]:bg-emerald-50/5">
+          <tbody class="[&_tr:nth-child(even)]:bg-slate-50">
             <tr *ngFor="let project of projects | slice:0:6">
               <td class="py-3 px-4">{{ project.name }}</td>
               <td class="py-3 px-4">{{ project.address || '—' }}</td>
@@ -50,15 +50,15 @@
     <!-- Right: Metrics stacked (top/bottom) -->
     <div class="grid gap-6">
       <!-- Managed listings (TOP) -->
-      <article class="grid gap-2 rounded-lg border border-emerald-50/10 bg-brand p-7 shadow-lg">
-        <span class="uppercase tracking-[0.2em] text-[0.72rem] text-emerald-50/55">Managed listings</span>
-        <strong class="font-serif text-4xl md:text-[2.6rem]">{{ projects.length }}</strong>
-        <small *ngIf="projectsError" class="text-rose-300">{{ projectsError }}</small>
+      <article class="grid gap-2 rounded-lg border border-slate-200 bg-white p-7 shadow-sm">
+        <span class="uppercase tracking-[0.2em] text-[0.72rem] text-slate-500">Managed listings</span>
+        <strong class="font-serif text-4xl md:text-[2.6rem] text-slate-900">{{ projects.length }}</strong>
+        <small *ngIf="projectsError" class="text-rose-500">{{ projectsError }}</small>
 
-        <div class="grid gap-2 text-emerald-50/60 text-sm">
-          <span class="relative block h-10 rounded-xl overflow-hidden">
+        <div class="grid gap-2 text-slate-600 text-sm">
+          <span class="relative block h-10 rounded-xl overflow-hidden bg-slate-100">
             <span
-              class="absolute inset-y-0 left-0 rounded-xl opacity-80 bg-gradient-to-r from-amber-400 to-amber-500/50"
+              class="absolute inset-y-0 left-0 rounded-xl bg-gradient-to-r from-brand to-accent"
               [style.width.%]="(projects.length % 12) / 12 * 100"
             ></span>
           </span>
@@ -66,15 +66,15 @@
       </article>
 
       <!-- Client inquiries (BOTTOM) -->
-      <article class="grid gap-2 rounded-lg border border-emerald-50/10 bg-brand p-7 shadow-lg">
-        <span class="uppercase tracking-[0.2em] text-[0.72rem] text-emerald-50/55">Client inquiries</span>
-        <strong class="font-serif text-4xl md:text-[2.6rem]">{{ totalInquiries }}</strong>
-        <small *ngIf="inquiriesError" class="text-rose-300">{{ inquiriesError }}</small>
+      <article class="grid gap-2 rounded-lg border border-slate-200 bg-white p-7 shadow-sm">
+        <span class="uppercase tracking-[0.2em] text-[0.72rem] text-slate-500">Client inquiries</span>
+        <strong class="font-serif text-4xl md:text-[2.6rem] text-slate-900">{{ totalInquiries }}</strong>
+        <small *ngIf="inquiriesError" class="text-rose-500">{{ inquiriesError }}</small>
 
-        <div class="grid gap-2 text-emerald-50/60 text-sm">
-          <span class="relative block h-2.5 rounded-full overflow-hidden bg-emerald-50/10">
+        <div class="grid gap-2 text-slate-600 text-sm">
+          <span class="relative block h-2.5 rounded-full overflow-hidden bg-slate-100">
             <span
-              class="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-amber-400 to-amber-500/50"
+              class="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-brand to-accent"
               [style.width.%]="Math.min(totalInquiries, 100)"
             ></span>
           </span>

--- a/frontend/ashaven-ui/src/app/features/dashboard/dashboard.component.html
+++ b/frontend/ashaven-ui/src/app/features/dashboard/dashboard.component.html
@@ -1,20 +1,20 @@
 <div
-  class="relative min-h-screen bg-brand text-pure md:grid md:grid-cols-[280px_1fr]"
+  class="relative min-h-screen bg-slate-50 text-slate-900 md:grid md:grid-cols-[280px_1fr]"
   (click)="closeSidebar($event)"
 >
   <aside
-    class="hidden h-full flex-col gap-10 border-r border-white/10 p-8 backdrop-blur xl:flex"
+    class="hidden h-full flex-col gap-10 border-r border-slate-200 bg-white p-8 xl:flex"
   >
     <div class="flex items-center gap-4">
       <span
-        class="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/20 bg-white/10 text-sm font-semibold tracking-[0.18em]"
+        class="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-200 bg-slate-100 text-sm font-semibold tracking-[0.18em] text-slate-600"
         >AE</span
       >
       <div class="space-y-1">
         <strong class="block font-serif text-lg uppercase tracking-[0.18em]"
           >Ashaven Estates</strong
         >
-        <span class="block text-xs uppercase tracking-[0.28em] text-white/60"
+        <span class="block text-xs uppercase tracking-[0.28em] text-slate-500"
           >Control Centre</span
         >
       </div>
@@ -29,8 +29,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           overviewRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-chart-line"></i>
@@ -43,8 +43,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           projectsRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-city"></i>
@@ -57,8 +57,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           clientsRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-user-tie"></i>
@@ -71,8 +71,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           teamsRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-users"></i>
@@ -86,8 +86,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           aboutRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-circle-info text-lg"></i>
@@ -101,8 +101,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           testimonialsRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-comment-dots"></i>
@@ -115,8 +115,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           galleryRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-images"></i>
@@ -129,8 +129,8 @@
         class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
         [ngClass]="
           faqRla.isActive
-            ? 'bg-accent text-pure shadow-[0_18px_45px_rgba(32,71,38,0.35)]'
-            : 'text-white/70 hover:bg-white/10 hover:text-white'
+            ? 'bg-brand text-white shadow-md'
+            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
         "
       >
         <i class="fas fa-question-circle"></i>
@@ -139,7 +139,7 @@
 
       <button
         type="button"
-        class="mt-auto flex items-center gap-3 rounded-2xl border border-white/10 px-4 py-3 text-sm font-medium text-white/70 transition hover:-translate-y-0.5 hover:border-white hover:text-white"
+        class="mt-auto flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:bg-slate-100 hover:text-slate-900"
         (click)="logout()"
       >
         <i class="fas fa-sign-out-alt"></i>
@@ -150,20 +150,20 @@
 
   <aside
     *ngIf="showSidebar"
-    class="fixed inset-0 z-50 flex bg-brand backdrop-blur-lg xl:hidden"
+    class="fixed inset-0 z-50 flex bg-slate-900/30 backdrop-blur-sm xl:hidden"
   >
     <div
-      class="flex w-full max-w-xs flex-col gap-6 border-r border-white/10 bg-brand p-6"
+      class="flex w-full max-w-xs flex-col gap-6 border-r border-slate-200 bg-white p-6"
     >
       <div
-        class="flex items-center justify-between text-xs uppercase tracking-[0.28em] text-white/60"
+        class="flex items-center justify-between text-xs uppercase tracking-[0.28em] text-slate-500"
       >
         <span>Navigate</span>
         <button
           type="button"
           (click)="toggleSidebar()"
           aria-label="Close navigation"
-          class="text-2xl text-white/70 transition hover:text-white"
+          class="text-2xl text-slate-500 transition hover:text-slate-900"
         >
           &times;
         </button>
@@ -178,8 +178,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileOverview.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-chart-line"></i>
@@ -193,8 +193,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileProjects.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-city"></i>
@@ -208,8 +208,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileClients.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-user-tie"></i>
@@ -223,8 +223,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileTeams.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-users"></i>
@@ -238,8 +238,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileTestimonials.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-comment-dots"></i>
@@ -253,8 +253,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileGallery.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-images"></i>
@@ -268,8 +268,8 @@
           class="flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition"
           [ngClass]="
             mobileFaq.isActive
-              ? 'bg-accent text-pure'
-              : 'text-white/70 hover:bg-white/10 hover:text-white'
+              ? 'bg-brand text-white'
+              : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
           "
         >
           <i class="fas fa-question-circle"></i>
@@ -277,7 +277,7 @@
         </a>
         <button
           type="button"
-          class="mt-4 flex items-center gap-3 rounded-2xl border border-white/10 px-4 py-3 text-sm font-medium text-white/70 transition hover:-translate-y-0.5 hover:border-white hover:text-white"
+          class="mt-4 flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-slate-300 hover:text-slate-900"
           (click)="logout()"
         >
           <i class="fas fa-sign-out-alt"></i>
@@ -289,11 +289,11 @@
 
   <div class="relative flex min-h-screen flex-col bg-white">
     <header
-      class="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-white/10 bg-brand px-6 py-4 backdrop-blur"
+      class="sticky top-0 z-20 flex items-center justify-between gap-4 border-b border-slate-200 bg-white px-6 py-4"
     >
       <button
         type="button"
-        class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-white/10 text-lg text-white transition hover:bg-white/20 xl:hidden"
+        class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-slate-100 text-lg text-slate-600 transition hover:bg-slate-200 xl:hidden"
         (click)="toggleSidebar()"
         aria-label="Toggle navigation"
       >
@@ -301,7 +301,7 @@
       </button>
 
       <div class="flex flex-col text-left">
-        <span class="text-xs uppercase tracking-[0.28em] text-white/60"
+        <span class="text-xs uppercase tracking-[0.28em] text-slate-500"
           >Welcome back, Agent</span
         >
         <strong class="font-serif text-xl">Performance dashboard</strong>
@@ -309,17 +309,17 @@
 
       <div class="flex items-center gap-4">
         <div
-          class="hidden items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm text-white/70 lg:flex"
+          class="hidden items-center gap-2 rounded-full border border-slate-200 bg-slate-100 px-4 py-2 text-sm text-slate-600 lg:flex"
         >
           <i class="fas fa-search"></i>
           <input
             type="text"
             placeholder="Search the portfolio"
-            class="w-40 bg-transparent text-sm text-white/80 placeholder:text-white/50 focus:outline-none"
+            class="w-40 bg-transparent text-sm text-slate-700 placeholder:text-slate-400 focus:outline-none"
           />
         </div>
         <button
-          class="relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-white/10 text-lg text-white transition hover:bg-white/20"
+          class="relative inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-slate-100 text-lg text-slate-600 transition hover:bg-slate-200"
           type="button"
           aria-label="Notifications"
         >
@@ -330,26 +330,26 @@
         </button>
         <div class="relative" (clickOutside)="closeProfileModal()">
           <button
-            class="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-accent text-sm font-semibold"
+            class="flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 bg-accent text-sm font-semibold text-white"
             (click)="toggleProfileDropdown()"
           >
             AE
           </button>
           <div
             *ngIf="showProfileDropdown"
-            class="absolute right-0 mt-2 w-44 rounded-2xl border border-white/10 bg-emerald-950/95 p-2 text-sm shadow-lg"
+            class="absolute right-0 mt-2 w-44 rounded-2xl border border-slate-200 bg-white p-2 text-sm shadow-lg"
           >
             <button
               type="button"
               (click)="openProfileModal()"
-              class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 transition hover:bg-white/10 hover:text-white"
+              class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-slate-700 transition hover:bg-slate-100 hover:text-slate-900"
             >
               Profile
             </button>
             <button
               type="button"
               (click)="logout()"
-              class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 transition hover:bg-white/10 hover:text-white"
+              class="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-slate-700 transition hover:bg-slate-100 hover:text-slate-900"
             >
               Logout
             </button>
@@ -368,10 +368,10 @@
 
 <div
   *ngIf="showProfileModal"
-  class="fixed inset-0 z-50 flex items-center justify-center backdrop-blur"
+  class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/30 backdrop-blur"
 >
   <div
-    class="w-[min(90%,26rem)] rounded-3xl border border-white/10 bg-emerald-950/95 p-8 text-white shadow-[0_24px_60px_rgba(0,0,0,0.45)]"
+    class="w-[min(90%,26rem)] rounded-3xl border border-slate-200 bg-white p-8 text-slate-900 shadow-xl"
   >
     <h2 class="font-serif text-2xl">Profile</h2>
     <form
@@ -380,38 +380,38 @@
       class="mt-6 flex flex-col gap-4"
     >
       <label
-        class="text-sm font-semibold uppercase tracking-[0.18em] text-white/70"
+        class="text-sm font-semibold uppercase tracking-[0.18em] text-slate-600"
         >Username</label
       >
       <input
         formControlName="username"
-        class="rounded-2xl border border-white/20 bg-white/10 px-4 py-2 text-sm text-white focus:border-accent focus:outline-none"
+        class="rounded-2xl border border-slate-300 bg-slate-100 px-4 py-2 text-sm text-slate-900 focus:border-accent focus:outline-none"
       />
 
       <label
-        class="text-sm font-semibold uppercase tracking-[0.18em] text-white/70"
+        class="text-sm font-semibold uppercase tracking-[0.18em] text-slate-600"
         >New Password</label
       >
       <input
         type="password"
         formControlName="password"
-        class="rounded-2xl border border-white/20 bg-white/10 px-4 py-2 text-sm text-white focus:border-accent focus:outline-none"
+        class="rounded-2xl border border-slate-300 bg-slate-100 px-4 py-2 text-sm text-slate-900 focus:border-accent focus:outline-none"
       />
 
       <label
-        class="text-sm font-semibold uppercase tracking-[0.18em] text-white/70"
+        class="text-sm font-semibold uppercase tracking-[0.18em] text-slate-600"
         >Confirm Password</label
       >
       <input
         type="password"
         formControlName="confirmPassword"
-        class="rounded-2xl border border-white/20 bg-white/10 px-4 py-2 text-sm text-white focus:border-accent focus:outline-none"
+        class="rounded-2xl border border-slate-300 bg-slate-100 px-4 py-2 text-sm text-slate-900 focus:border-accent focus:outline-none"
       />
 
       <div class="mt-4 flex justify-end gap-3">
         <button
           type="button"
-          class="rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white/80 transition hover:border-white hover:text-white"
+          class="rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
           (click)="closeProfileModal()"
         >
           Cancel

--- a/frontend/ashaven-ui/src/app/services/lenis.service.ts
+++ b/frontend/ashaven-ui/src/app/services/lenis.service.ts
@@ -16,6 +16,7 @@ export class LenisService {
   private readonly scrollSubject = new BehaviorSubject<number>(0);
   private readonly windowScroll$?: Observable<number>;
   private motionQuery?: MediaQueryList;
+  private viewportQuery?: MediaQueryList;
   private rafId?: number;
   private lenisScrollCallback?: (event: ScrollEvent) => void;
 
@@ -28,6 +29,7 @@ export class LenisService {
     }
 
     this.motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    this.viewportQuery = window.matchMedia('(max-width: 768px)');
     this.windowScroll$ = fromEvent(window, 'scroll', { passive: true }).pipe(
       startWith(window.scrollY || window.pageYOffset || 0),
       map(() => window.scrollY || window.pageYOffset || 0),
@@ -49,6 +51,22 @@ export class LenisService {
       this.motionQuery.addEventListener('change', handleMotionPreference);
     } else if (typeof this.motionQuery.addListener === 'function') {
       this.motionQuery.addListener(handleMotionPreference);
+    }
+
+    const handleViewportPreference = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        this.stopLenis();
+      } else {
+        this.init();
+      }
+    };
+
+    if (this.viewportQuery) {
+      if (typeof this.viewportQuery.addEventListener === 'function') {
+        this.viewportQuery.addEventListener('change', handleViewportPreference);
+      } else if (typeof this.viewportQuery.addListener === 'function') {
+        this.viewportQuery.addListener(handleViewportPreference);
+      }
     }
 
     this.router.events
@@ -157,6 +175,10 @@ export class LenisService {
 
     const prefersReducedMotion = this.motionQuery ?? window.matchMedia('(prefers-reduced-motion: reduce)');
     if (prefersReducedMotion.matches) {
+      return false;
+    }
+
+    if (this.viewportQuery?.matches) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- disable Lenis smooth scrolling on touch-sized viewports and listen for viewport changes to restore native scrolling on mobile
- replace the scroll-to-top animation binding with a CSS visibility toggle so the control renders consistently
- restyle the dashboard shell and overview cards with a lighter neutral palette for a simpler presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec84f5ace48323b8e42372afcddba9