### PR TITLE
Reduce scroll-induced change detection in blog hero

### DIFF
--- a/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.html
+++ b/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.html
@@ -8,7 +8,7 @@
     <div
       class="absolute -top-16 left-0 h-[130%] w-full bg-cover bg-center transition-transform duration-500 parallax-bg"
       style="background-image: url('/images/banner/banner-3.png')"
-      
+      [style.transform]="scrollTransform"
     ></div>
     <div class="absolute inset-0 from-emerald-950/85 via-emerald-900/70 to-brand/70"></div>
   </div>

--- a/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.ts
@@ -1,6 +1,13 @@
-import { Component, HostListener } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgZone,
+  OnDestroy,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ScrollService } from '../../../services/scroll.service';
 
 @Component({
   selector: 'app-hero-section',
@@ -8,11 +15,30 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
   templateUrl: './hero-section.component.html',
   styleUrl: './hero-section.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HeroSectionComponent {
-  scrollY = 0;
-  @HostListener('window:scroll', ['$event'])
-    onWindowScroll() {
-      this.scrollY = window.scrollY;
-    }
+export class HeroSectionComponent implements OnDestroy {
+  scrollTransform = 'translateY(-60px)';
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(private scrollService: ScrollService, private zone: NgZone) {
+    this.zone.runOutsideAngular(() => {
+      this.scrollService.scrollY$
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((scrollY) => {
+          const transform = `translateY(${scrollY * 0.3 - 60}px)`;
+          if (transform !== this.scrollTransform) {
+            this.zone.run(() => {
+              this.scrollTransform = transform;
+            });
+          }
+        });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 }


### PR DESCRIPTION
## Summary
- replace the blog hero window scroll HostListener with a Lenis-based scroll subscription that runs outside Angular's zone
- bind the hero banner background transform to the throttled scroll stream while using OnPush change detection to minimize work during scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f31a4237e48323ab2a5bd634a3c427