### PR TITLE
Reduce scroll and carousel main-thread work

### DIFF
--- a/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
+++ b/frontend/ashaven-ui/src/app/components/scroll-to-top/scroll-to-top.component.ts
@@ -6,8 +6,8 @@ import {
   OnInit,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { fromEvent, merge, Observable, Subject } from 'rxjs';
-import { distinctUntilChanged, map, startWith, takeUntil, throttleTime } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
 import { ScrollService } from '../../services/scroll.service';
 import { LenisService } from '../../services/lenis.service';
 
@@ -30,21 +30,21 @@ export class ScrollToTopComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    const fallbackScroll$ = this.createFallbackScroll$();
-    const scroll$ = fallbackScroll$
-      ? merge(this.scrollService.scrollY$, fallbackScroll$)
-      : this.scrollService.scrollY$;
-
     this.zone.runOutsideAngular(() => {
-      scroll$
-        .pipe(takeUntil(this.destroy$))
-        .subscribe((scrollY) => {
-          const shouldBeVisible = scrollY > 200;
-          if (shouldBeVisible !== this.isVisible) {
-            this.zone.run(() => {
-              this.isVisible = shouldBeVisible;
-            });
+      this.scrollService.scrollY$
+        .pipe(
+          map((scrollY) => scrollY > 200),
+          distinctUntilChanged(),
+          takeUntil(this.destroy$)
+        )
+        .subscribe((shouldBeVisible) => {
+          if (shouldBeVisible === this.isVisible) {
+            return;
           }
+
+          this.zone.run(() => {
+            this.isVisible = shouldBeVisible;
+          });
         });
     });
   }
@@ -56,18 +56,5 @@ export class ScrollToTopComponent implements OnInit, OnDestroy {
 
   scrollToTop() {
     this.lenisService.scrollTo(0, { duration: 0.8 });
-  }
-
-  private createFallbackScroll$(): Observable<number> | null {
-    if (typeof window === 'undefined') {
-      return null;
-    }
-
-    return fromEvent(window, 'scroll', { passive: true }).pipe(
-      startWith(window.scrollY || window.pageYOffset || 0),
-      map(() => window.scrollY || window.pageYOffset || 0),
-      throttleTime(50, undefined, { leading: true, trailing: true }),
-      distinctUntilChanged()
-    );
   }
 }

--- a/frontend/ashaven-ui/src/app/components/slider/slider.component.ts
+++ b/frontend/ashaven-ui/src/app/components/slider/slider.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   ViewChild,
   CUSTOM_ELEMENTS_SCHEMA,
+  NgZone,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -39,15 +40,20 @@ export class SliderComponent implements OnInit, AfterViewInit, OnDestroy {
   slides: Slide[] = [];
   baseUrl = environment.baseUrl;
   private subscription = new Subscription();
+  private intersectionObserver?: IntersectionObserver;
+  private isSliderVisible = false;
+  private pendingInit = false;
+  private isSwiperInitialized = false;
 
-  constructor(private projectService: ProjectService) {}
+  constructor(private projectService: ProjectService, private ngZone: NgZone) {}
 
   ngOnInit(): void {
     this.loadProjects();
   }
 
   ngAfterViewInit(): void {
-    // nothing here — initialization happens after slides are loaded and rendered
+    this.setupIntersectionObserver();
+    this.queueSwiperInit();
   }
 
   private loadProjects() {
@@ -67,8 +73,8 @@ export class SliderComponent implements OnInit, AfterViewInit, OnDestroy {
               project.description || 'Discover elegance in every detail.',
           }));
 
-          // Wait a tick so Angular renders <swiper-slide> nodes, then initialize Swiper element
-          setTimeout(() => this.initSwiper(), 50);
+          this.teardownSwiper();
+          this.queueSwiperInit();
         },
         error: (err) => {
           console.error('Error loading projects:', err);
@@ -91,64 +97,164 @@ export class SliderComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
-    // If already initialized, destroy first (safe-guard)
-    try {
-      if (swiperEl.swiper && typeof swiperEl.swiper.destroy === 'function') {
-        swiperEl.swiper.destroy(true, true);
-      }
-    } catch (e) {
-      // ignore
-    }
+    this.ngZone.runOutsideAngular(() => {
+      this.teardownSwiper();
 
-    // Assign configuration as properties (use JS props because we used init="false")
-    Object.assign(swiperEl, {
-      // core
-      slidesPerView: 3,
-      spaceBetween: 24,
-      loop: true,
-      speed: 800,
-
-      // autoplay module
-      autoplay: {
-        delay: 4000,
-        disableOnInteraction: false,
-      },
-
-      // navigation - selectors must exist in DOM at initialize time
-      navigation: {
-        nextEl: '.neo-slider__control--next',
-        prevEl: '.neo-slider__control--prev',
-      },
-
-      // pagination - we will place an element with class .swiper-pagination in template
-      pagination: {
-        el: '.swiper-pagination',
-        clickable: true,
-      },
-
-      breakpoints: {
-        0: { slidesPerView: 1 }, // 📱 Mobile
-        640: { slidesPerView: 1 }, // Small tablets
-        768: { slidesPerView: 2 }, // Medium tablets
-        1024: { slidesPerView: 3 }, // Laptops/desktops
-      },
-
-      // events (optional)
-      on: {
-        init() {
-          // console.log('swiper init', arguments);
+      Object.assign(swiperEl, {
+        slidesPerView: 3,
+        spaceBetween: 24,
+        loop: true,
+        speed: 800,
+        autoplay: {
+          delay: 4000,
+          disableOnInteraction: false,
         },
-        slideChange() {
-          // console.log('slide changed');
+        navigation: {
+          nextEl: '.neo-slider__control--next',
+          prevEl: '.neo-slider__control--prev',
         },
-      },
+        pagination: {
+          el: '.swiper-pagination',
+          clickable: true,
+        },
+        breakpoints: {
+          0: { slidesPerView: 1 },
+          640: { slidesPerView: 1 },
+          768: { slidesPerView: 2 },
+          1024: { slidesPerView: 3 },
+        },
+      });
+
+      swiperEl.initialize();
     });
 
-    // Initialize
-    swiperEl.initialize();
+    this.isSwiperInitialized = true;
+    this.resumeSwiper();
   }
 
   ngOnDestroy(): void {
     this.subscription.unsubscribe();
+    this.intersectionObserver?.disconnect();
+    this.pauseSwiper();
+    this.teardownSwiper();
+  }
+
+  private setupIntersectionObserver(): void {
+    if (typeof window === 'undefined') {
+      this.isSliderVisible = true;
+      return;
+    }
+
+    const element = this.swiperRef?.nativeElement;
+    if (!element) {
+      this.isSliderVisible = true;
+      return;
+    }
+
+    if (!('IntersectionObserver' in window)) {
+      this.isSliderVisible = true;
+      return;
+    }
+
+    this.ngZone.runOutsideAngular(() => {
+      this.intersectionObserver = new IntersectionObserver(
+        (entries) => {
+          const entry = entries[0];
+          const isIntersecting = !!entry?.isIntersecting;
+
+          if (isIntersecting === this.isSliderVisible) {
+            return;
+          }
+
+          this.isSliderVisible = isIntersecting;
+
+          if (isIntersecting) {
+            this.queueSwiperInit();
+          } else {
+            this.pauseSwiper();
+          }
+        },
+        {
+          threshold: 0.15,
+          rootMargin: '0px 0px 200px 0px',
+        }
+      );
+
+      this.intersectionObserver.observe(element);
+    });
+  }
+
+  private queueSwiperInit(): void {
+    if (this.pendingInit || !this.isSliderVisible || !this.swiperRef || !this.slides.length) {
+      return;
+    }
+
+    this.pendingInit = true;
+
+    if (typeof window === 'undefined') {
+      this.pendingInit = false;
+      return;
+    }
+
+    this.ngZone.runOutsideAngular(() => {
+      requestAnimationFrame(() => {
+        this.pendingInit = false;
+        this.maybeInitSwiper();
+      });
+    });
+  }
+
+  private maybeInitSwiper(): void {
+    if (!this.swiperRef || !this.slides.length) {
+      return;
+    }
+
+    if (this.isSwiperInitialized) {
+      this.resumeSwiper();
+      return;
+    }
+
+    if (!this.isSliderVisible) {
+      return;
+    }
+
+    this.initSwiper();
+  }
+
+  private teardownSwiper(): void {
+    const swiperEl = this.swiperRef?.nativeElement as any;
+    const instance = swiperEl?.swiper;
+
+    if (instance && typeof instance.destroy === 'function') {
+      try {
+        instance.destroy(true, true);
+      } catch (e) {
+        // ignore teardown errors
+      }
+    }
+
+    this.isSwiperInitialized = false;
+  }
+
+  private pauseSwiper(): void {
+    const swiper = (this.swiperRef?.nativeElement as any)?.swiper;
+    if (swiper?.autoplay?.running) {
+      try {
+        swiper.autoplay.stop();
+      } catch (e) {
+        // ignore
+      }
+    }
+  }
+
+  private resumeSwiper(): void {
+    const swiper = (this.swiperRef?.nativeElement as any)?.swiper;
+    if (swiper?.autoplay && !swiper.autoplay.running) {
+      try {
+        swiper.autoplay.start();
+      } catch (e) {
+        // ignore
+      }
+    }
   }
 }

--- a/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.html
+++ b/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.html
@@ -5,11 +5,17 @@
   aria-labelledby="aboutHeroTitle"
 >
   <div class="absolute inset-0">
-    <div
-      class="absolute -top-16 left-0 h-[130%] w-full bg-cover bg-center transition-transform duration-500 parallax-bg"
-      style="background-image: url('/images/banner/banner-3.png')"
-      
-    ></div>
+    <img
+      ngSrc="/images/banner/banner-3.png"
+      width="1920"
+      height="1080"
+      decoding="async"
+      priority
+      fetchpriority="high"
+      alt=""
+      class="absolute -top-16 left-0 h-[130%] w-full object-cover transition-transform duration-500 will-change-transform parallax-bg"
+      [style.transform]="scrollTransform"
+    />
     <div class="absolute inset-0 from-emerald-950/85 via-emerald-900/70 to-brand/70"></div>
   </div>
 

--- a/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.ts
+++ b/frontend/ashaven-ui/src/app/pages/blog/hero-section/hero-section.component.ts
@@ -1,18 +1,44 @@
-import { Component, HostListener } from '@angular/core';
-import { CommonModule } from '@angular/common';
-
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgZone,
+  OnDestroy,
+} from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { ScrollService } from '../../../services/scroll.service';
 
 @Component({
   selector: 'app-hero-section',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, NgOptimizedImage],
   templateUrl: './hero-section.component.html',
-  styleUrl: './hero-section.component.css',
+  styleUrls: ['./hero-section.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HeroSectionComponent {
-  scrollY = 0;
-  @HostListener('window:scroll', ['$event'])
-    onWindowScroll() {
-      this.scrollY = window.scrollY;
-    }
+export class HeroSectionComponent implements OnDestroy {
+  scrollTransform = 'translateY(-60px)';
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(private scrollService: ScrollService, private zone: NgZone) {
+    this.zone.runOutsideAngular(() => {
+      this.scrollService.scrollY$
+        .pipe(takeUntil(this.destroy$))
+        .subscribe((scrollY) => {
+          const transform = `translateY(${scrollY * 0.3 - 60}px)`;
+          if (transform !== this.scrollTransform) {
+            this.zone.run(() => {
+              this.scrollTransform = transform;
+            });
+          }
+        });
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 }

--- a/frontend/ashaven-ui/src/app/services/lenis.service.ts
+++ b/frontend/ashaven-ui/src/app/services/lenis.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NgZone } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { BehaviorSubject, Observable, fromEvent, of } from 'rxjs';
+import { BehaviorSubject, Observable, Subscription, fromEvent, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, shareReplay, startWith } from 'rxjs/operators';
 import Lenis from '@studio-freight/lenis';
 
@@ -19,6 +19,11 @@ export class LenisService {
   private viewportQuery?: MediaQueryList;
   private rafId?: number;
   private lenisScrollCallback?: (event: ScrollEvent) => void;
+  private motionPreferenceListener?: (event: MediaQueryListEvent) => void;
+  private viewportPreferenceListener?: (event: MediaQueryListEvent) => void;
+  private routerSubscription?: Subscription;
+  private fallbackScrollSubscription?: Subscription;
+  private lastEmittedScroll = 0;
 
   readonly scroll$: Observable<number> = this.scrollSubject.asObservable();
 
@@ -37,9 +42,11 @@ export class LenisService {
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-    this.scrollSubject.next(window.scrollY || window.pageYOffset || 0);
+    const initialScroll = this.getWindowScrollPosition();
+    this.scrollSubject.next(initialScroll);
+    this.lastEmittedScroll = initialScroll;
 
-    const handleMotionPreference = (event: MediaQueryListEvent) => {
+    this.motionPreferenceListener = (event: MediaQueryListEvent) => {
       if (event.matches) {
         this.stopLenis();
       } else {
@@ -48,12 +55,12 @@ export class LenisService {
     };
 
     if (typeof this.motionQuery.addEventListener === 'function') {
-      this.motionQuery.addEventListener('change', handleMotionPreference);
+      this.motionQuery.addEventListener('change', this.motionPreferenceListener);
     } else if (typeof this.motionQuery.addListener === 'function') {
-      this.motionQuery.addListener(handleMotionPreference);
+      this.motionQuery.addListener(this.motionPreferenceListener);
     }
 
-    const handleViewportPreference = (event: MediaQueryListEvent) => {
+    this.viewportPreferenceListener = (event: MediaQueryListEvent) => {
       if (event.matches) {
         this.stopLenis();
       } else {
@@ -63,18 +70,18 @@ export class LenisService {
 
     if (this.viewportQuery) {
       if (typeof this.viewportQuery.addEventListener === 'function') {
-        this.viewportQuery.addEventListener('change', handleViewportPreference);
+        this.viewportQuery.addEventListener('change', this.viewportPreferenceListener);
       } else if (typeof this.viewportQuery.addListener === 'function') {
-        this.viewportQuery.addListener(handleViewportPreference);
+        this.viewportQuery.addListener(this.viewportPreferenceListener);
       }
     }
 
-    this.router.events
+    this.routerSubscription = this.router.events
       .pipe(filter((event) => event instanceof NavigationEnd))
       .subscribe(() => {
         if (!this.lenis) {
           window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
-          this.scrollSubject.next(0);
+          this.emitScroll(0);
           return;
         }
 
@@ -114,17 +121,12 @@ export class LenisService {
     body.classList.add('has-lenis');
 
     this.lenisScrollCallback = (event: ScrollEvent) => {
-      this.scrollSubject.next(event.scroll);
+      this.emitScroll(event.scroll);
     };
 
     this.lenis.on('scroll', this.lenisScrollCallback);
 
-    const runRaf = (time: number) => {
-      this.lenis?.raf(time);
-      this.scheduleRaf(runRaf);
-    };
-
-    this.scheduleRaf(runRaf);
+    this.startAnimationLoop();
   }
 
   onScroll(callback: (scroll: number) => void): void {
@@ -203,13 +205,50 @@ export class LenisService {
     this.lenis = undefined;
 
     if (typeof window !== 'undefined') {
-      this.scrollSubject.next(window.scrollY || window.pageYOffset || 0);
+      this.emitScroll(this.getWindowScrollPosition());
     }
   }
 
-  private scheduleRaf(callback: FrameRequestCallback): void {
+  cleanup(): void {
+    this.stopLenis();
+
+    if (this.motionQuery && this.motionPreferenceListener) {
+      if (typeof this.motionQuery.removeEventListener === 'function') {
+        this.motionQuery.removeEventListener('change', this.motionPreferenceListener);
+      } else if (typeof this.motionQuery.removeListener === 'function') {
+        this.motionQuery.removeListener(this.motionPreferenceListener);
+      }
+    }
+    this.motionPreferenceListener = undefined;
+
+    if (this.viewportQuery && this.viewportPreferenceListener) {
+      if (typeof this.viewportQuery.removeEventListener === 'function') {
+        this.viewportQuery.removeEventListener('change', this.viewportPreferenceListener);
+      } else if (typeof this.viewportQuery.removeListener === 'function') {
+        this.viewportQuery.removeListener(this.viewportPreferenceListener);
+      }
+    }
+    this.viewportPreferenceListener = undefined;
+
+    this.routerSubscription?.unsubscribe();
+    this.routerSubscription = undefined;
+
+    this.fallbackScrollSubscription?.unsubscribe();
+    this.fallbackScrollSubscription = undefined;
+  }
+
+  private startAnimationLoop(): void {
+    if (this.rafId) {
+      return;
+    }
+
     this.ngZone.runOutsideAngular(() => {
-      this.rafId = requestAnimationFrame(callback);
+      const runRaf = (time: number) => {
+        this.lenis?.raf(time);
+        this.rafId = requestAnimationFrame(runRaf);
+      };
+
+      this.rafId = requestAnimationFrame(runRaf);
     });
   }
 
@@ -221,9 +260,28 @@ export class LenisService {
     }
 
     this.ngZone.runOutsideAngular(() => {
-      windowScroll$
+      this.fallbackScrollSubscription?.unsubscribe();
+      this.fallbackScrollSubscription = windowScroll$
         .pipe(filter(() => !this.lenis))
-        .subscribe((scrollY) => this.scrollSubject.next(scrollY));
+        .subscribe((scrollY) => this.emitScroll(scrollY));
     });
+  }
+
+  private emitScroll(scrollY: number): void {
+    const roundedScroll = Math.round(scrollY);
+    if (roundedScroll === this.lastEmittedScroll) {
+      return;
+    }
+
+    this.lastEmittedScroll = roundedScroll;
+    this.scrollSubject.next(roundedScroll);
+  }
+
+  private getWindowScrollPosition(): number {
+    if (typeof window === 'undefined') {
+      return 0;
+    }
+
+    return Math.round(window.scrollY || window.pageYOffset || 0);
   }
 }

--- a/frontend/ashaven-ui/src/app/services/lenis.service.ts
+++ b/frontend/ashaven-ui/src/app/services/lenis.service.ts
@@ -19,6 +19,8 @@ export class LenisService {
   private viewportQuery?: MediaQueryList;
   private rafId?: number;
   private lenisScrollCallback?: (event: ScrollEvent) => void;
+  private loopStarter?: () => void;
+  private loopStartEvents?: string[];
   private motionPreferenceListener?: (event: MediaQueryListEvent) => void;
   private viewportPreferenceListener?: (event: MediaQueryListEvent) => void;
   private routerSubscription?: Subscription;
@@ -141,6 +143,7 @@ export class LenisService {
     }
 
     if (this.lenis) {
+      this.scheduleAnimationFrame();
       this.lenis.scrollTo(target, options);
       return;
     }
@@ -193,6 +196,8 @@ export class LenisService {
       this.rafId = undefined;
     }
 
+    this.unbindLoopStarters();
+
     document.documentElement.classList.remove('has-lenis');
     document.body.classList.remove('has-lenis');
 
@@ -238,18 +243,68 @@ export class LenisService {
   }
 
   private startAnimationLoop(): void {
-    if (this.rafId) {
+    this.bindLoopStarters();
+    this.scheduleAnimationFrame();
+  }
+
+  private scheduleAnimationFrame(): void {
+    if (this.rafId || !this.lenis) {
       return;
     }
 
     this.ngZone.runOutsideAngular(() => {
-      const runRaf = (time: number) => {
+      const onFrame = (time: number) => {
         this.lenis?.raf(time);
-        this.rafId = requestAnimationFrame(runRaf);
+
+        if (this.lenis && this.isLenisActive()) {
+          this.rafId = requestAnimationFrame(onFrame);
+        } else {
+          this.rafId = undefined;
+        }
       };
 
-      this.rafId = requestAnimationFrame(runRaf);
+      this.rafId = requestAnimationFrame(onFrame);
     });
+  }
+
+  private isLenisActive(): boolean {
+    if (!this.lenis) {
+      return false;
+    }
+
+    return this.lenis.isScrolling;
+  }
+
+  private bindLoopStarters(): void {
+    if (typeof window === 'undefined' || this.loopStartEvents?.length) {
+      return;
+    }
+
+    this.loopStarter ??= () => this.scheduleAnimationFrame();
+
+    const events: Array<{ type: string; options?: AddEventListenerOptions }> = [
+      { type: 'wheel', options: { passive: true } },
+      { type: 'touchstart', options: { passive: true } },
+      { type: 'touchmove', options: { passive: true } },
+      { type: 'keydown' },
+    ];
+
+    this.loopStartEvents = events.map(({ type }) => type);
+
+    this.ngZone.runOutsideAngular(() => {
+      events.forEach(({ type, options }) => {
+        window.addEventListener(type, this.loopStarter as EventListener, options);
+      });
+    });
+  }
+
+  private unbindLoopStarters(): void {
+    if (typeof window === 'undefined' || !this.loopStartEvents?.length || !this.loopStarter) {
+      return;
+    }
+
+    this.loopStartEvents.forEach((type) => window.removeEventListener(type, this.loopStarter as EventListener));
+    this.loopStartEvents = undefined;
   }
 
   private handleFallbackScroll(): void {


### PR DESCRIPTION
## Summary
- run Lenis scroll emissions through integer rounding and guard against duplicate RAF loops to reduce change detection churn
- lazily initialize and pause the Swiper carousel when offscreen and tear it down before reloads to cut requestAnimationFrame and autoplay work
- optimize the blog hero banner image with NgOptimizedImage priority loading and simplify the scroll-to-top visibility stream to remove redundant window listeners

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f31a4237e48323ab2a5bd634a3c427